### PR TITLE
Setup cgroups on RHEL family

### DIFF
--- a/recipes/cgroups.rb
+++ b/recipes/cgroups.rb
@@ -1,14 +1,14 @@
 # TODO: Platforms handled here should be fixed in control_groups cookbook
 # Possibly: https://github.com/hw-cookbooks/control_groups/
-case node['platform']
-when 'oracle' || 'rhel'
+if platform_family?('rhel')
   package 'libcgroup'
 
   service 'cgconfig' do
     supports :status => true, :restart => true, :reload => true
     action [:enable, :start]
   end
-when 'ubuntu'
+end
+if platform?('ubuntu')
   package 'cgroup-bin'
 
   if node['platform_version'] == '12.04'

--- a/recipes/cgroups.rb
+++ b/recipes/cgroups.rb
@@ -1,7 +1,7 @@
 # TODO: Platforms handled here should be fixed in control_groups cookbook
 # Possibly: https://github.com/hw-cookbooks/control_groups/
 case node['platform']
-when 'oracle'
+when 'oracle' || 'rhel'
   package 'libcgroup'
 
   service 'cgconfig' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,7 +55,7 @@ unless node['docker']['install_type'] == 'package'
   end
   if node['docker']['install_type'] == 'binary'
     include_recipe 'git'
-    include_recipe 'iptables'
+    include_recipe 'iptables::disabled'
     include_recipe 'docker::cgroups'
 
     node['docker']['binary']['dependency_packages'].each do |p|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -56,6 +56,7 @@ unless node['docker']['install_type'] == 'package'
   if node['docker']['install_type'] == 'binary'
     include_recipe 'git'
     include_recipe 'iptables'
+    include_recipe 'docker::cgroups'
 
     node['docker']['binary']['dependency_packages'].each do |p|
       package p


### PR DESCRIPTION
When I was installing and testing the Docker recipe on local test-kitchen CentOS and RHEL boxes, I found that even though Docker gets installed correctly, it actually isn't usable and fails on the first Docker pull because the cgroup mounts are properly configured. The workaround I discovered was to modify the cgroups recipe to work on RHEL family boxes and then execute it before the default docker recipe. With that in place, the binary installation works great.

This PR modifies the binary installation recipe to ensure cgroups are setup correctly, and modifies the cgroups recipe to also execute against RHEL family OSes.

Thank you for taking a look!