### PR TITLE
Correct comparison of default container names

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -153,8 +153,8 @@ def container_image_matches?(image)
 end
 
 def container_name_matches?(names)
-  return false unless names && new_resource.container_name
-  return true if names.split(',').include?(new_resource.container_name)
+  return false unless names && container_name
+  return true if names.split(',').include?(container_name)
   false
 end
 


### PR DESCRIPTION
A container resource with a service without an explicit `container_name` attribute was not idempotent. Checking the running state of the container by name requires lookup by the same name assumed at launch time, which in this case is some default value.

See https://github.com/bflad/chef-docker/issues/184#issuecomment-56533201