### PR TITLE
(On Ubuntu 12.04) Start Docker only after cgconfig started

### DIFF
--- a/recipes/cgroups.rb
+++ b/recipes/cgroups.rb
@@ -12,6 +12,13 @@ when 'ubuntu'
   package 'cgroup-bin'
 
   if node['platform_version'] == '12.04'
+    template '/etc/init/cgconfig.conf' do
+      source 'cgconfig.conf.erb'
+      mode '0644'
+      owner 'root'
+      group 'root'
+    end
+
     service 'cgconfig' do
       action :start
     end

--- a/templates/default/cgconfig.conf.erb
+++ b/templates/default/cgconfig.conf.erb
@@ -1,0 +1,38 @@
+description "cgconfig"
+author "Serge E. Hallyn <serge.hallyn@ubuntu.com>"
+
+start on (runlevel [2345] and starting docker)
+
+console output
+
+pre-start script
+  test -x /usr/sbin/cgconfigparser || { stop; exit 0; }
+
+  CREATE_DEFAULT="yes"
+  CGCONFIG=/etc/cgconfig.conf
+  if [ -r /etc/default/cgconfig ]; then
+    . /etc/default/cgconfig
+  fi
+
+  # If we've already run, don't do it again!
+  if grep -q /sys/fs/cgroup /proc/mounts; then
+    stop
+    exit 0
+  fi
+
+  [ -r $CGCONFIG ] || { echo "$CGCONFIG is empty"; stop; exit 0; }
+
+  mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroups /sys/fs/cgroup
+  /usr/sbin/cgconfigparser -l $CGCONFIG
+  if [ "$CREATE_DEFAULT" = "yes" ]; then
+    /usr/sbin/create_default_cgroups
+  fi
+end script
+
+post-stop script
+  if [ -x /usr/sbin/cgclear ]
+  then
+    /usr/sbin/cgclear
+  fi
+  umount /sys/fs/cgroup || true
+end script

--- a/templates/default/docker.conf.erb
+++ b/templates/default/docker.conf.erb
@@ -1,6 +1,6 @@
 description "Docker daemon"
 
-start on (local-filesystems and net-device-up IFACE!=lo)
+start on (local-filesystems and net-device-up IFACE!=lo and started cgconfig)
 stop on runlevel [!2345]
 limit nofile 524288 1048576
 limit nproc 524288 1048576

--- a/templates/default/docker.conf.erb
+++ b/templates/default/docker.conf.erb
@@ -1,6 +1,6 @@
 description "Docker daemon"
 
-start on (local-filesystems and net-device-up IFACE!=lo and started cgconfig)
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 limit nofile 524288 1048576
 limit nproc 524288 1048576


### PR DESCRIPTION
On Ubuntu 12.04 without this change, the `docker` service starts before `cgconfig`, and I get the following error whenever starting a Docker container:

```
[error] container.go:815 Error running container: cgroup mountpoint not found for cpu
```

The only modification from the default `cgconfig` upstart script is that 

```
start on runlevel [2345]
```

has been changed to

```
start on (runlevel [2345] and starting docker)
```

Overall, this change doesn't feel quite clean, so I'm happy to edit is as you suggest.