### PR TITLE
fixed the installation to run on centos 7.0.1406

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -80,7 +80,11 @@ default['docker']['package']['name'] = value_for_platform(
   'amazon' => {
     'default' => 'docker'
   },
-  %w(centos fedora redhat) => {
+  'centos' => {
+      '7.0.1406' => 'docker',
+      'default' => 'docker-io'
+  },
+  %w(fedora redhat) => {
     'default' => 'docker-io'
   },
   'debian' => {

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -5,7 +5,7 @@ when 'amazon', 'centos', 'fedora', 'redhat'
   include_recipe 'yum-epel' if %w(centos redhat).include?(node['platform'])
 
   package p do
-    version node['docker']['version']
+    version node['docker']['version'] if not %w(centos).include?(node['platform'])
     action node['docker']['package']['action'].intern
   end
 when 'debian', 'ubuntu'


### PR DESCRIPTION
1.the yum package is now (in centos 7) "docker" instead of "docker-io" http://stackoverflow.com/questions/25423840/how-to-install-docker-on-centos-7
2.the version line causes an error of the kind "no version specified, and no candidate version available" under centos

tested with  a docker centos7 image