### PR TITLE
Lengthen shell_out timeout as workaround for slow docker_container action stop.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -647,7 +647,7 @@ def stop
   if service?
     service_stop
   else
-    docker_cmd!("stop #{stop_args} #{current_resource.id}", (new_resource.cmd_timeout + 15))
+    docker_cmd!("stop #{stop_args} #{current_resource.id}", (new_resource.cmd_timeout + 30))
   end
 end
 


### PR DESCRIPTION
On at least 2 of my servers the `docker stop` command runs unusually slow. As the benchmark below shows, stopping a container seems to take around 20s more than the graceful stop delay. In this PR, I workaround the issue by increasing the shell_out timeout from its current 15 (already a workaround) to 30 seconds.

```
root@staging2-ng:~# time docker stop --time=1 125b758d437f
125b758d437f

real	0m22.546s
user	0m0.010s
sys	0m0.007s
root@staging2-ng:~# time docker stop --time=1 fd00d6158eaa
fd00d6158eaa

real	0m22.698s
user	0m0.007s
sys	0m0.010s
root@prod1-ng:~# time docker stop --time=1 1 509ca18cf34e
509ca18cf34e

real	0m23.603s
user	0m0.009s
sys	0m0.007s
```

Have to investigate the issue more and see if I should open a bug report on docker github, but since the problem shows on multiple servers I submit this PR as workaround.