### PR TITLE
fix the location from which settings are source when using upstart on el6

### DIFF
--- a/recipes/upstart.rb
+++ b/recipes/upstart.rb
@@ -7,6 +7,9 @@ template docker_upstart_conf_file do
   mode '0600'
   owner 'root'
   group 'root'
+  variables(
+    'docker_settings_file' => docker_settings_file
+  )
 end
 
 template docker_settings_file do

--- a/spec/upstart_spec.rb
+++ b/spec/upstart_spec.rb
@@ -30,6 +30,13 @@ describe 'docker::upstart' do
     it 'creates the docker sysconfig template in /etc/sysconfig' do
       expect(chef_run).to create_template('/etc/sysconfig/docker')
     end
+
+    it 'sources settings from /etc/sysconfig' do
+      # Ensure the script section of the upstart configuration
+      # is sourcing from sysconfig.
+      expect(chef_run).to render_file('/etc/init/docker.conf').with_content(
+        /script.*?. \/etc\/sysconfig\/docker.*?end script/m)
+    end
   end
 
   context 'when api_enable_cors is set' do

--- a/templates/default/docker.conf.erb
+++ b/templates/default/docker.conf.erb
@@ -31,11 +31,11 @@ pre-start script
 end script
 
 script
-    # modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+    # modify these in <%= @docker_settings_file %>
     DOCKER=/usr/bin/$UPSTART_JOB
     DOCKER_OPTS=
-    if [ -f /etc/default/$UPSTART_JOB ]; then
-        . /etc/default/$UPSTART_JOB
+    if [ -f <%= @docker_settings_file %> ]; then
+        . <%= @docker_settings_file %>
     fi
     exec "$DOCKER" -d $DOCKER_OPTS
 end script


### PR DESCRIPTION
Currently the upstart configuration is hard code to source its settings from `/etc/default/$UPSTART_JOB`, however the helper module method `docker_settings_file` returns `/etc/sysconfig/docker` so this is where all the `daemon_options` are written to. This has the effect that none of the daemon options are honored.

