### PR TITLE
Consistency between docker_image name and docker_container image attributes?

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ These attributes are associated with this LWRP action.
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
 force | Force operation | Boolean | false
-repository | Remote repository | String | nil
+repository | Optional remote repository | String | nil
 tag | Specific tag for image | String | nil
 
 Tag image:

--- a/README.md
+++ b/README.md
@@ -622,6 +622,33 @@ Attribute | Description | Type | Default
 ----------|-------------|------|--------
 cmd_timeout | Timeout for docker commands (catchable exception: `Chef::Provider::Docker::Image::CommandTimeout`) | Integer | `node['docker']['image_cmd_timeout']`
 
+#### Note about image tags
+
+If not specified, the image tag is assumed to be 'latest'.
+
+The image tag may be specified either:
+ - by using the optional `tag` attribute (works for most LWRP actions except `:tag`)
+ - by appending the image tag to the image name attribute using ':' as separator
+
+As an example:
+
+```ruby
+docker_image 'myImage' do
+  tag 'myTag'
+  action :pull
+end
+```
+
+And
+
+```ruby
+docker_image 'myImage:myTag' do
+  action :pull
+end
+```
+
+Should both result in the `myImage:myTag` image being pulled.
+
 #### docker_image action :build and :build_if_missing
 
 These attributes are associated with this LWRP action.
@@ -855,6 +882,16 @@ Tag image:
 
 ```ruby
 docker_image 'test' do
+  repository 'bflad'
+  tag '1.0.0'
+  action :tag
+end
+```
+
+Tag image with non-default tag:
+
+```ruby
+docker_image 'test:non-latest' do
   repository 'bflad'
   tag '1.0.0'
   action :tag

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -188,9 +188,9 @@ end
 
 def import
   if ::File.file?(new_resource.source)
-    execute_cmd("cat #{new_resource.source} | docker import - #{repository_and_tag_args}")
+    execute_cmd("cat #{new_resource.source} | docker import - #{repository_image_and_tag_args}")
   elsif ::File.directory?(new_resource.source)
-    execute_cmd("tar -c #{new_resource.source} | docker import - #{repository_and_tag_args}")
+    execute_cmd("tar -c #{new_resource.source} | docker import - #{repository_image_and_tag_args}")
   else
     import_args = ''
     if new_resource.image_url
@@ -201,7 +201,7 @@ def import
       import_args += new_resource.source
       import_args += " #{new_resource.image_name}"
     end
-    docker_cmd!("import #{import_args} #{repository_and_tag_args}")
+    docker_cmd!("import #{import_args} #{repository_image_and_tag_args}")
   end
 end
 
@@ -251,11 +251,10 @@ def remove
   docker_cmd!("rmi #{remove_args} #{image_name}")
 end
 
-def repository_and_tag_args
+def repository_image_and_tag_args
   docker_cmd_args = ''
   docker_cmd_args += new_resource.repository + '/' if new_resource.repository
-  docker_cmd_args += new_resource.image_name.split(':', 2).first # strip tag if any
-  docker_cmd_args += ":#{new_resource.tag}" if new_resource.tag
+  docker_cmd_args += image_and_tag_arg
   docker_cmd_args
 end
 
@@ -276,5 +275,5 @@ def tag
   tag_args = cli_args(
     'force' => new_resource.force
   )
-  docker_cmd!("tag #{tag_args} #{new_resource.image_name} #{repository_and_tag_args}")
+  docker_cmd!("tag #{tag_args} #{new_resource.image_name} #{repository_image_and_tag_args}")
 end

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -169,7 +169,7 @@ def image_name_matches?(name)
 end
 
 def image_tag_matches_if_exists?(tag, alt_image_tag)
-  unless new_resource_has_any_tag_setting_action?
+  if new_resource_has_no_setting_action?
     # For most actions except those that interpret the 'tag' attribute as
     # the consequence of running the action (eg. action :tag), the 'tag'
     # attribute (implicitly 'latest') is the tag of the current_resource,
@@ -182,8 +182,8 @@ def image_tag_matches_if_exists?(tag, alt_image_tag)
   end
 end
 
-def new_resource_has_any_tag_setting_action?
-  Array(new_resource.action).any? { |action| action == :tag }
+def new_resource_has_no_setting_action?
+  Array(new_resource.action).none? { |action| action == :tag }
 end
 
 def import

--- a/providers/image.rb
+++ b/providers/image.rb
@@ -2,13 +2,17 @@ include Docker::Helpers
 
 def load_current_resource
   wait_until_ready!
-  @current_resource = Chef::Resource::DockerImage.new(new_resource.name)
+  # extract image tag from the name attribute if present.
+  image_name_without_tag, alt_image_tag = new_resource.name.split(':', 2)
+  new_resource.image_name(image_name_without_tag)
+  new_resource.tag(alt_image_tag) unless new_resource.tag
+  @current_resource = Chef::Resource::DockerImage.new(image_name_without_tag)
   dimages = docker_cmd('images -a --no-trunc')
   if dimages.stdout.include?(new_resource.image_name)
     dimages.stdout.each_line do |di_line|
       image = di(di_line)
       next unless image_name_matches?(image['repository'])
-      next unless image_tag_matches_if_exists?(image['tag'])
+      next unless image_tag_matches_if_exists?(image['tag'], alt_image_tag)
       Chef::Log.debug('Matched docker image: ' + di_line.squeeze(' '))
       @current_resource.created(image['created'])
       @current_resource.repository(image['repository'])
@@ -164,9 +168,22 @@ def image_name_matches?(name)
   name.include?(new_resource.image_name)
 end
 
-def image_tag_matches_if_exists?(tag)
-  return false if new_resource.tag && new_resource.tag != tag
-  true
+def image_tag_matches_if_exists?(tag, alt_image_tag)
+  unless new_resource_has_any_tag_setting_action?
+    # For most actions except those that interpret the 'tag' attribute as
+    # the consequence of running the action (eg. action :tag), the 'tag'
+    # attribute (implicitly 'latest') is the tag of the current_resource,
+    return tag == (new_resource.tag || 'latest')
+  else
+    # For tag-setting actions, we cannot rely on the 'tag' attribute to specify
+    # the image tag of the current_resource; if by chance the user has provided
+    # the actual tag in the name attribute then use that else assume 'latest'.
+    return tag == (alt_image_tag || 'latest')
+  end
+end
+
+def new_resource_has_any_tag_setting_action?
+  Array(new_resource.action).any? { |action| action == :tag }
 end
 
 def import
@@ -236,10 +253,9 @@ end
 
 def repository_and_tag_args
   docker_cmd_args = ''
-  if new_resource.repository
-    docker_cmd_args = new_resource.repository
-    docker_cmd_args += ":#{new_resource.tag}" if new_resource.tag
-  end
+  docker_cmd_args += new_resource.repository + '/' if new_resource.repository
+  docker_cmd_args += new_resource.image_name.split(':', 2).first # strip tag if any
+  docker_cmd_args += ":#{new_resource.tag}" if new_resource.tag
   docker_cmd_args
 end
 

--- a/test/cookbooks/docker_test/files/default/tests/minitest/image_lwrp_test.rb
+++ b/test/cookbooks/docker_test/files/default/tests/minitest/image_lwrp_test.rb
@@ -22,4 +22,8 @@ describe_recipe 'docker_test::image_lwrp_test' do
   it 'has docker_image_build_2 image installed' do
     assert image_exists?('docker_image_build_2')
   end
+
+  it 'has busybox:busyboxWithCustomTag image installed' do
+    assert image_exists?('busyboxWithCustomTag')
+  end
 end

--- a/test/cookbooks/docker_test/recipes/image_lwrp.rb
+++ b/test/cookbooks/docker_test/recipes/image_lwrp.rb
@@ -35,3 +35,9 @@ docker_image 'docker_image_build_2' do
   source docker_image_build_2_dir
   action :build
 end
+
+docker_image 'busybox' do
+  tag 'busyboxWithCustomTag'
+  force true
+  action :tag
+end

--- a/test/cookbooks/docker_test/recipes/image_lwrp.rb
+++ b/test/cookbooks/docker_test/recipes/image_lwrp.rb
@@ -41,3 +41,7 @@ docker_image 'busybox' do
   force true
   action :tag
 end
+
+docker_image 'busybox:busyboxWithCustomTag' do
+  action :pull_if_missing
+end

--- a/test/shared/spec/image_spec.rb
+++ b/test/shared/spec/image_spec.rb
@@ -19,4 +19,8 @@ shared_examples_for 'a docker image test environment' do
     describe docker_imag('docker_image_build_2') do
       it { should be_a_image }
     end
+
+    describe docker_imag('busybox:busyboxWithCustomTag') do
+      it { should be_a_image }
+    end
 end


### PR DESCRIPTION
I stumbled upon that one while trying to pull an docker image with a non-default (latest) tag and then use that same image to deploy a container.

Here is how the docker_image resource should be declared:

```ruby
docker_image 'busybox' do
  tag 'ubuntu-14.04'
  action :pull_if_missing
end
```

Here is how the docker_container container is declared:

```ruby
docker_container 'my-container' do
  image 'busybox:ubuntu-14.04'
  command 'sleep 1111'
end
```

At first, I declared my image resource same as the image attribute of the docker_container resource (it is DRY and follows the principle of the last surprise):

```ruby
docker_image 'busybox:ubuntu-14.04' do
  action :pull_if_missing
end
```

It appeared to work, except that the docker image was always being pulled (even if not missing) and the resource was always modified_by_last_action. This wasted around 3 seconds per docker_image resource and made my chef-runs longer than what it should be.

I found out later than the docker_image `tag` attribute has to be specified separately and not as part of the name attribute (if the tag is part of the name attribute then resource will instanciate however `#load_current_resource` won't detect the existing container).

@bflad @tduffield  would you be interested in a PR that splits the docker_image name attribute into image_name and image_tag attributes automatically? This would be backward compatible and would make it easier for developers to pull an image that has a non-default (latest) tag then deploy a container based on this same image.