### PR TITLE
Use registry on image inspection

### DIFF
--- a/providers/image.rb
+++ b/providers/image.rb
@@ -64,9 +64,9 @@ action :pull_if_missing do
 end
 
 action :pull do
-  old_hash = docker_inspect_id(image_and_tag_arg)
+  old_hash = docker_inspect_id(registry_image_and_tag_arg)
   pull
-  new_hash = docker_inspect_id(image_and_tag_arg)
+  new_hash = docker_inspect_id(registry_image_and_tag_arg)
   new_resource.updated_by_last_action(new_hash != old_hash)
 end
 


### PR DESCRIPTION
When you are using custom registries `pull` command will not trigger notifications as expected because it will compare wrong ids.