### PR TITLE
Fix accidental port changing when using systemd templates.

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -624,7 +624,7 @@ end
 
 def sockets
   return [] if port.empty?
-  [*port].map { |p| p.gsub!(/.*:/, '') }
+  [*port].map { |p| p.gsub(/.*:/, '') }
 end
 
 def start


### PR DESCRIPTION
When you use `port.gsub!` - you are changing the value  port variable
itself, and as long as the value is not local to this method, but
is a part of new_resource record (when it's passed as an array or
string) - the previous code will modify `new_resource.port` instance
variable.