### PR TITLE
Add additional_host attribute to container resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ These attributes are associated with this LWRP action.
 
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
+additional_host | Add a custom host-to-IP mapping (host:ip) | String, Array | nil
 attach | Attach container's stdout/stderr and forward all signals to the process | TrueClass, FalseClass | nil
 cidfile | File to store container ID | String | nil
 container_name | Name for container/service | String | nil

--- a/providers/container.rb
+++ b/providers/container.rb
@@ -361,6 +361,7 @@ end
 # rubocop:disable MethodLength
 def run_cli_args
   {
+    'add-host' => Array(new_resource.additional_host),
     'cpu-shares' => new_resource.cpu_shares,
     'cidfile' => new_resource.cidfile,
     'detach' => new_resource.detach,

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -4,6 +4,7 @@ default_action :run
 
 attribute :image, :name_attribute => true
 
+attribute :additional_host, :kind_of => [String, Array]
 attribute :attach, :kind_of => [TrueClass, FalseClass]
 attribute :author, :kind_of => [String]
 attribute :cidfile, :kind_of => [String]


### PR DESCRIPTION
It corresponds to `--add-host` CLI argument, described here:
https://docs.docker.com/reference/run/.