### PR TITLE
Updated the /etc/init/docker.conf template.

### DIFF
--- a/templates/default/docker.conf.erb
+++ b/templates/default/docker.conf.erb
@@ -8,34 +8,51 @@ limit nproc 524288 1048576
 respawn
 
 pre-start script
-  # see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
-  if grep -v '^#' /etc/fstab | grep -q cgroup \
-    || [ ! -e /proc/cgroups ] \
-    || [ ! -d /sys/fs/cgroup ]; then
-    exit 0
-  fi
-  if ! mountpoint -q /sys/fs/cgroup; then
-    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
-  fi
-  (
-    cd /sys/fs/cgroup
-    for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
-      mkdir -p $sys
-      if ! mountpoint -q $sys; then
-        if ! mount -n -t cgroup -o $sys cgroup $sys; then
-          rmdir $sys || true
-        fi
-      fi
-    done
-  )
+	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+	if grep -v '^#' /etc/fstab | grep -q cgroup \
+		|| [ ! -e /proc/cgroups ] \
+		|| [ ! -d /sys/fs/cgroup ]; then
+		exit 0
+	fi
+	if ! mountpoint -q /sys/fs/cgroup; then
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+	fi
+	(
+		cd /sys/fs/cgroup
+		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+			mkdir -p $sys
+			if ! mountpoint -q $sys; then
+				if ! mount -n -t cgroup -o $sys cgroup $sys; then
+					rmdir $sys || true
+				fi
+			fi
+		done
+	)
 end script
 
 script
-    # modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
-    DOCKER=/usr/bin/$UPSTART_JOB
-    DOCKER_OPTS=
-    if [ -f /etc/default/$UPSTART_JOB ]; then
-        . /etc/default/$UPSTART_JOB
-    fi
-    exec "$DOCKER" -d $DOCKER_OPTS
+	# modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+	DOCKER=/usr/bin/$UPSTART_JOB
+	DOCKER_OPTS=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+	exec "$DOCKER" -d $DOCKER_OPTS
+end script
+
+# Don't emit "started" event until docker.sock is ready.
+# See https://github.com/docker/docker/issues/6647
+post-start script
+	DOCKER_OPTS=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
+		while ! [ -e /var/run/docker.sock ]; do
+			initctl status $UPSTART_JOB | grep -q "stop/" && exit 1
+			echo "Waiting for /var/run/docker.sock"
+			sleep 0.1
+		done
+		echo "/var/run/docker.sock is up"
+	fi
 end script


### PR DESCRIPTION
This PR brings our upstart docker service template up to date with the original at https://github.com/docker/docker/blob/master/contrib/init/upstart/docker.conf .

I found out about the issue when upgrading to lxc-docker 1.5.0; dpkg asked me if I want to replace the `/etc/init/docker.conf` file or keep my change. Ironically, the changes in the file are related to fixing an issue that I reported a while ago on the docker github that got merged last December.