### PR TITLE
Fixes BIP configuration errors by drastically shifting init script configuration

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,14 +15,14 @@ provisioner:
 
 
 platforms:
-- name: centos-6.5
-  driver_config:
-    box: opscode-centos-6.5
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-- name: centos-7.0
-  driver_config:
-    box: opscode-centos-7.0
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
+#- name: centos-6.5
+#  driver_config:
+#    box: opscode-centos-6.5
+#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+#- name: centos-7.0
+#  driver_config:
+#    box: opscode-centos-7.0
+#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
 #- name: oracle-6
 #- name: macosx-10.7
 #- name: macosx-10.8
@@ -37,18 +37,18 @@ platforms:
 #   driver_config:
 #     box: opscode-debian-7.7
 #     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.7_chef-provisionerless.box
-- name: fedora-19
-  driver_config:
-    box: opscode-fedora-19
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-19_chef-provisionerless.box
-- name: fedora-20
-  driver_config:
-    box: opscode-fedora-20
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
-- name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+#- name: fedora-19
+#  driver_config:
+#    box: opscode-fedora-19
+#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-19_chef-provisionerless.box
+#- name: fedora-20
+#  driver_config:
+#    box: opscode-fedora-20
+#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
+#- name: ubuntu-12.04
+#  driver_config:
+#    box: opscode-ubuntu-12.04
+#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
 #
 # There appears to be an issue with the apt cookbook on 13.04. We will eventually
 # take care of this but for the time being we are disabling this platform

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,14 +15,14 @@ provisioner:
 
 
 platforms:
-#- name: centos-6.5
-#  driver_config:
-#    box: opscode-centos-6.5
-#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
-#- name: centos-7.0
-#  driver_config:
-#    box: opscode-centos-7.0
-#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
+- name: centos-6.5
+  driver_config:
+    box: opscode-centos-6.5
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+- name: centos-7.0
+  driver_config:
+    box: opscode-centos-7.0
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
 #- name: oracle-6
 #- name: macosx-10.7
 #- name: macosx-10.8
@@ -37,18 +37,18 @@ platforms:
 #   driver_config:
 #     box: opscode-debian-7.7
 #     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.7_chef-provisionerless.box
-#- name: fedora-19
-#  driver_config:
-#    box: opscode-fedora-19
-#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-19_chef-provisionerless.box
-#- name: fedora-20
-#  driver_config:
-#    box: opscode-fedora-20
-#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
-#- name: ubuntu-12.04
-#  driver_config:
-#    box: opscode-ubuntu-12.04
-#    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+- name: fedora-19
+  driver_config:
+    box: opscode-fedora-19
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-19_chef-provisionerless.box
+- name: fedora-20
+  driver_config:
+    box: opscode-fedora-20
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box
+- name: ubuntu-12.04
+  driver_config:
+    box: opscode-ubuntu-12.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
 #
 # There appears to be an issue with the apt cookbook on 13.04. We will eventually
 # take care of this but for the time being we are disabling this platform

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Docker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.36.0'
+version '0.36.1'
 
 recipe 'docker', 'Installs/Configures Docker'
 recipe 'docker::aufs', 'Installs/Loads AUFS Linux module'

--- a/recipes/systemd.rb
+++ b/recipes/systemd.rb
@@ -22,8 +22,8 @@ template '/usr/lib/systemd/system/docker.service' do
   notifies :restart, 'service[docker]', :immediately
 end
 
-service 'docker' do
+service Docker::Helpers.docker_service(node) do
   provider Chef::Provider::Service::Systemd
   supports :status => true, :restart => true, :reload => true
-  action [:start, :enable]
+  action [:nothing]
 end

--- a/recipes/sysv.rb
+++ b/recipes/sysv.rb
@@ -18,7 +18,7 @@ template docker_settings_file do
   notifies :restart, 'service[docker]', :immediately
 end
 
-service 'docker' do
+service Docker::Helpers.docker_service(node) do
   supports :status => true, :restart => true, :reload => true
-  action [:start, :enable]
+  action [:nothing]
 end

--- a/recipes/upstart.rb
+++ b/recipes/upstart.rb
@@ -19,12 +19,12 @@ template docker_settings_file do
   )
   # DEPRECATED: stop and start only necessary for 0.x cookbook upgrades
   # Default docker Upstart job now sources default file for DOCKER_OPTS
-  notifies :stop, "service[#{docker_service}]", :immediately
-  notifies :start, "service[#{docker_service}]", :immediately
+  notifies :stop, "service[#{docker_service}]", :delayed
+  notifies :start, "service[#{docker_service}]", :delayed
 end
 
 service docker_service do
   provider Chef::Provider::Service::Upstart
   supports :status => true, :restart => true, :reload => true
-  action [:start]
+  action [:nothing]
 end

--- a/spec/systemd_spec.rb
+++ b/spec/systemd_spec.rb
@@ -490,12 +490,4 @@ describe 'docker::systemd' do
         /^Environment="TMPDIR=\/tmp"$/)
     end
   end
-
-  it 'starts the docker service' do
-    expect(chef_run).to start_service('docker')
-  end
-
-  it 'enables the docker service' do
-    expect(chef_run).to enable_service('docker')
-  end
 end

--- a/spec/sysv_spec.rb
+++ b/spec/sysv_spec.rb
@@ -519,12 +519,4 @@ describe 'docker::sysv' do
         /^export TMPDIR="\/tmp"$/)
     end
   end
-
-  it 'starts the docker service' do
-    expect(chef_run).to start_service('docker')
-  end
-
-  it 'enables the docker service' do
-    expect(chef_run).to enable_service('docker')
-  end
 end

--- a/spec/upstart_spec.rb
+++ b/spec/upstart_spec.rb
@@ -17,8 +17,8 @@ describe 'docker::upstart' do
       expect(chef_run).to render_file('/etc/default/docker').with_content(
         %r{^DOCKER="/usr/bin/docker"$})
       resource = chef_run.template('/etc/default/docker')
-      expect(resource).to notify('service[docker]').to(:stop).immediately
-      expect(resource).to notify('service[docker]').to(:start).immediately
+      expect(resource).to notify('service[docker]').to(:stop).delayed
+      expect(resource).to notify('service[docker]').to(:start).delayed
     end
   end
 
@@ -519,9 +519,5 @@ describe 'docker::upstart' do
       expect(chef_run).to render_file('/etc/default/docker').with_content(
         /^export TMPDIR="\/tmp"$/)
     end
-  end
-
-  it 'starts the docker service' do
-    expect(chef_run).to start_service('docker')
   end
 end


### PR DESCRIPTION
Currently if you try to set the bridge ip via the docker defaults file you will get a hard failure.  This is caused by the  package installation of docker which automatically starts the service.  If you then stop the service and try to set the BIP (in the docker defaults file) it will explode saying that the BIP's do not match.

What I have done here is shift the init script recipe to appear BEFORE package installation.  I have also set the init scripts to take action :nothing by default.  Once the scripts are laid down and the package is installed, at the end of the default recipe it will look for the service resources and then set their actions to :start and :enable.

Other possible solutions:
  1. Setup init scripts to delete bridges before starting docker
  2. Have the package installation stop the service and delete the bridge it created upon installation
  3. When you install the deb use the argument `-o Dpkg::Options::="--force-confold"`

Either way this is sort of a problem, I know that v1 of the cookbook is being worked on.  Hopefully it doesn't suffer from this issue.
