### PR TITLE
Allow docker_container memory to have String value (eg. memory='1G').

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ init_template | Template to use for init configuration | String | nil
 link | Add link to another container | String, Array | nil
 label | Options to pass to underlying labeling system | String | nil
 lxc_conf | Custom LXC options | String, Array | nil
-memory | Set memory limit for container | Fixnum | nil
+memory | Set memory limit for container | Fixnum, String | nil
 net | [Configure networking](http://docs.docker.io/reference/run/#network-settings) for container | String | nil
 networking (*DEPRECATED*) | Configure networking for container | TrueClass, FalseClass | true
 opt | Custom driver options | String, Array | nil

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -32,7 +32,7 @@ attribute :init_template, :kind_of => [String]
 attribute :link, :kind_of => [String, Array]
 attribute :label, :kind_of => [String]
 attribute :lxc_conf, :kind_of => [String, Array]
-attribute :memory, :kind_of => [Fixnum]
+attribute :memory, :kind_of => [Fixnum, String]
 attribute :message, :kind_of => [String]
 attribute :net, :kind_of => [String], :regex => [
   /(host|bridge|none)/, /container:.*/


### PR DESCRIPTION
This very modest PR allows String values for docker_container memory attribute.

Currently, the docker_container resource only allows `Fixnum` values for the attribute (in other words, memory value is implicitly in bytes) but the docker [documentation](https://docs.docker.com/reference/run/#runtime-constraints-on-cpu-and-memory) says that the `docker run --memory` parameter supports optional units. It is also possible to specify different memory and memory+swap limits.

With this PR I can set `docker.memory = '1G'` or `docker.memory = '150m,200m'`, while still allowing for Fixnum memory values as before.