### PR TITLE
port function shouldn't return nil...

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -299,7 +299,7 @@ def port
   elsif new_resource.port && new_resource.port.is_a?(Fixnum)
     ":#{new_resource.port}"
   else
-    new_resource.port
+    new_resource.port || []
   end
 end
 


### PR DESCRIPTION
... otherwise port.empty? raises a *undefined method `empty?' for nil:NilClass*