### PR TITLE
redhat 7 does not need the epel repository

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -2,7 +2,8 @@ p = node['docker']['package']['name']
 
 case node['platform']
 when 'amazon', 'centos', 'fedora', 'redhat'
-  include_recipe 'yum-epel' if %w(centos redhat).include?(node['platform'])
+  include_recipe 'yum-epel' if node['platform'] == "centos"
+  include_recipe 'yum-epel' if node['platform'] == "redhat" && node['platform_version'].to_f < 7
 
   package p do
     version node['docker']['version']

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -2,8 +2,8 @@ p = node['docker']['package']['name']
 
 case node['platform']
 when 'amazon', 'centos', 'fedora', 'redhat'
-  include_recipe 'yum-epel' if node['platform'] == "centos"
-  include_recipe 'yum-epel' if node['platform'] == "redhat" && node['platform_version'].to_f < 7
+  include_recipe 'yum-epel' if node['platform'] == 'centos'
+  include_recipe 'yum-epel' if node['platform'] == 'redhat' && node['platform_version'].to_f < 7
 
   package p do
     version node['docker']['version']


### PR DESCRIPTION
Redhat 7 ships the `docker` package in the `rhel-7-server-extras-rpms` repo.

See: https://docs.docker.com/installation/rhel/#red-hat-enterprise-linux-7-installation