### PR TITLE
Fix docker.socket unit for RHEL7

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -143,7 +143,7 @@ default['docker']['exec_driver'] = nil
 default['docker']['virtualization_type'] = node['docker']['exec_driver']
 
 default['docker']['graph'] = nil
-default['docker']['group'] = node['docker']['group_members'].empty? ? nil : 'docker' 
+default['docker']['group'] = node['docker']['group_members'].empty? ? nil : 'docker'
 
 # DEPRECATED: Support for bind_socket/bind_uri
 default['docker']['host'] =

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -143,7 +143,7 @@ default['docker']['exec_driver'] = nil
 default['docker']['virtualization_type'] = node['docker']['exec_driver']
 
 default['docker']['graph'] = nil
-default['docker']['group'] = nil
+default['docker']['group'] = node['docker']['group_members'].empty? ? nil : 'docker' 
 
 # DEPRECATED: Support for bind_socket/bind_uri
 default['docker']['host'] =

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,5 +81,5 @@ unless node['docker']['install_type'] == 'package'
 end
 
 include_recipe "docker::#{node['docker']['install_type']}"
-include_recipe 'docker::group' unless node['docker']['group_members'].empty?
+include_recipe 'docker::group' if node['docker']['group']
 include_recipe "docker::#{node['docker']['init_type']}"

--- a/templates/default/docker.socket.erb
+++ b/templates/default/docker.socket.erb
@@ -7,7 +7,7 @@ ListenStream=<%= socket.gsub(/^unix:\/\//,'').gsub(/^tcp:\/\//,'').gsub(/^fd:\/\
 <% end -%>
 SocketMode=0660
 SocketUser=root
-SocketGroup=docker
+SocketGroup=<%= node['docker']['group'] || 'root' %>
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
The latest RHEL 7 docker rpm docker-1.4.1-37.el7 does not create a docker group anymore. This breaks the socker.socket unit file which defaults to *docker* for the socket group.

This post explains some details for not shipping a docker group by default for security reasons some more:
https://lists.projectatomic.io/projectatomic-archives/atomic-devel/2015-January/msg00034.html