### PR TITLE
ensure --host fd:// when using socket activation

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -82,7 +82,7 @@ EOH
         'dns' => Array(node['docker']['dns']),
         'dns-search' => Array(node['docker']['dns_search']),
         'exec-driver' => node['docker']['exec_driver'],
-        'host' => Array(node['docker']['host']),
+        'host' => node['docker']['init_type'] == 'systemd' ? ['fd://'] : Array(node['docker']['host']),
         'graph' => node['docker']['graph'],
         'group' => node['docker']['group'],
         'icc' => node['docker']['icc'],


### PR DESCRIPTION
For socket activation to actually work the docker daemon needs to be started with `--host fd://` as all connections are handed via a file descriptor from the docker.socket unit.