### PR TITLE
Rubocop fixes for regexes

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -181,7 +181,7 @@ end
 
 def container_name
   if service?
-    new_resource.container_name || new_resource.image.gsub(/^.*\//, '')
+    new_resource.container_name || new_resource.image.gsub(%r{^.*/}, '')
   else
     new_resource.container_name
   end
@@ -258,7 +258,7 @@ def docker_containers
     # Filter out technical names (eg. 'my-app/db'), which appear in ps['names']
     # when a container has at least another container linking to it. If these
     # names are not filtered they will pollute current_resource.container_name.
-    ps['names'] = ps['names'].split(',').grep(/\A[^\/]+\Z/).join(',') # technical names always contain a '/'
+    ps['names'] = ps['names'].split(',').grep(%r{\A[^\/]+\Z}).join(',') # technical names always contain a '/'
     ps
   end
 end

--- a/spec/systemd_spec.rb
+++ b/spec/systemd_spec.rb
@@ -253,7 +253,7 @@ describe 'docker::systemd' do
 
     it 'sets NO_PROXY environment variable in docker service' do
       expect(chef_run).to render_file('/usr/lib/systemd/system/docker.service').with_content(
-        /^Environment="NO_PROXY=host1.example.com,111.111.111.0\/24"/)
+        %r{^Environment="NO_PROXY=host1.example.com,111.111.111.0/24"})
     end
   end
 
@@ -487,7 +487,7 @@ describe 'docker::systemd' do
 
     it 'sets TMPDIR environment variable in docker service' do
       expect(chef_run).to render_file('/usr/lib/systemd/system/docker.service').with_content(
-        /^Environment="TMPDIR=\/tmp"$/)
+        %r{^Environment="TMPDIR=/tmp"$})
     end
   end
 

--- a/spec/sysv_spec.rb
+++ b/spec/sysv_spec.rb
@@ -264,7 +264,7 @@ describe 'docker::sysv' do
 
     it 'sets NO_PROXY environment variable in docker service' do
       expect(chef_run).to render_file('/etc/default/docker').with_content(
-        /^export NO_PROXY=host1.example.com,111.111.111.0\/24$/)
+        %r{^export NO_PROXY=host1.example.com,111.111.111.0/24$})
     end
   end
 
@@ -516,7 +516,7 @@ describe 'docker::sysv' do
 
     it 'sets TMPDIR environment variable in docker service' do
       expect(chef_run).to render_file('/etc/default/docker').with_content(
-        /^export TMPDIR="\/tmp"$/)
+        %r{^export TMPDIR="/tmp"$})
     end
   end
 

--- a/spec/upstart_spec.rb
+++ b/spec/upstart_spec.rb
@@ -265,7 +265,7 @@ describe 'docker::upstart' do
 
     it 'sets NO_PROXY environment variable in docker service' do
       expect(chef_run).to render_file('/etc/default/docker').with_content(
-        /^export NO_PROXY=host1.example.com,111.111.111.0\/24$/)
+        %r{^export NO_PROXY=host1.example.com,111.111.111.0/24$})
     end
   end
 
@@ -517,7 +517,7 @@ describe 'docker::upstart' do
 
     it 'sets TMPDIR environment variable in docker service' do
       expect(chef_run).to render_file('/etc/default/docker').with_content(
-        /^export TMPDIR="\/tmp"$/)
+        %r{^export TMPDIR="\/tmp"$})
     end
   end
 


### PR DESCRIPTION
```
Inspecting 53 files
.................C................................CCC

Offenses:

providers/container.rb:184:60: C: Use %r around regular expression.
    new_resource.container_name || new_resource.image.gsub(/^.*\//, '')
                                                           ^^^^^^^
providers/container.rb:261:47: C: Use %r around regular expression.
    ps['names'] = ps['names'].split(',').grep(/\A[^\/]+\Z/).join(',') # technical names always contain a '/'
                                              ^^^^^^^^^^^^
spec/systemd_spec.rb:256:9: C: Use %r around regular expression.
        /^Environment="NO_PROXY=host1.example.com,111.111.111.0\/24"/)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/systemd_spec.rb:490:9: C: Use %r around regular expression.
        /^Environment="TMPDIR=\/tmp"$/)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/sysv_spec.rb:267:9: C: Use %r around regular expression.
        /^export NO_PROXY=host1.example.com,111.111.111.0\/24$/)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/sysv_spec.rb:519:9: C: Use %r around regular expression.
        /^export TMPDIR="\/tmp"$/)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
spec/upstart_spec.rb:268:9: C: Use %r around regular expression.
        /^export NO_PROXY=host1.example.com,111.111.111.0\/24$/)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/upstart_spec.rb:520:9: C: Use %r around regular expression.
        /^export TMPDIR="\/tmp"$/)
        ^^^^^^^^^^^^^^^^^^^^^^^^^

53 files inspected, 8 offenses detected
```

```
2.1.2 :001 > image = 'bflad/testcontainerd'
 => "bflad/testcontainerd"
2.1.2 :002 > image.gsub(/^.*\//, '')
 => "testcontainerd"
2.1.2 :003 > image.gsub(%r{^.*/}, '')
 => "testcontainerd"

2.1.2 :001 > names = 'foo,bar,bflad/testcontainerd'
 => "foo,bar,bflad/testcontainerd"
2.1.2 :002 > names.split(',').grep(/\A[^\/]+\Z/).join(',')
 => "foo,bar"
2.1.2 :003 > names.split(',').grep(%r{\A[^\/]+\Z}).join(',')
 => "foo,bar"
```

```
Inspecting 53 files
.....................................................

53 files inspected, no offenses detected
```