### PR TITLE
Default systemd to fd:// as well as use upstream MountFlags=slave and LimitCORE=infinity

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -149,6 +149,8 @@ default['docker']['group'] = node['docker']['group_members'].empty? ? nil : 'doc
 default['docker']['host'] =
   if node['docker']['bind_socket'] || node['docker']['bind_uri']
     Array(node['docker']['bind_socket']) + Array(node['docker']['bind_uri'])
+  elsif node['docker']['init_type'] == 'systemd'
+    'fd://'
   else
     'unix:///var/run/docker.sock'
   end

--- a/templates/default/docker.service.erb
+++ b/templates/default/docker.service.erb
@@ -25,8 +25,10 @@ ExecStartPre=/usr/sbin/sysctl -w net.ipv4.ip_forward=1
 ExecStartPre=/usr/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
 <% end -%>
 ExecStart=<%= Docker::Helpers.executable(node) %> -d<%= @daemon_options %>
+MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
+LimitCORE=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
More information about systemd changes below, which will default docker host to `fd://` among other unit file changes.

`ExecStart=... -H fd://`:
* https://github.com/docker/docker/commit/076ac1d7d212c3a81a401a2fba8b9965bc26df16

`LimitCORE=infinity`:
* https://github.com/docker/docker/commit/ae9cdbbde7824951b124a648e897ac4c291108e3
* http://www.freedesktop.org/software/systemd/man/systemd.exec.html#LimitCPU=

`MountFlags=slave`:
* https://github.com/docker/docker/commit/eb76cb2301fc883941bc4ca2d9ebc3a486ab8e0a
* http://www.freedesktop.org/software/systemd/man/systemd.exec.html#MountFlags=
