### PR TITLE
Update docker daemon SysV init scripts with upstream improvements

### DIFF
--- a/templates/debian/docker.sysv.erb
+++ b/templates/debian/docker.sysv.erb
@@ -1,9 +1,12 @@
 #!/bin/sh
+set -e
 
 ### BEGIN INIT INFO
 # Provides:           docker
 # Required-Start:     $syslog $remote_fs
 # Required-Stop:      $syslog $remote_fs
+# Should-Start:       cgroupfs-mount cgroup-lite
+# Should-Stop:        cgroupfs-mount cgroup-lite
 # Default-Start:      2 3 4 5
 # Default-Stop:       0 1 6
 # Short-Description:  Create lightweight, portable, self-sufficient containers.
@@ -20,7 +23,10 @@ BASE=$(basename $0)
 
 # modify these in /etc/default/$BASE (/etc/default/docker)
 DOCKER=/usr/bin/$BASE
+# This is the pid file managed by docker itself
 DOCKER_PIDFILE=/var/run/$BASE.pid
+# This is the pid file created/managed by start-stop-daemon
+DOCKER_SSD_PIDFILE=/var/run/$BASE-ssd.pid
 DOCKER_LOGFILE=/var/log/$BASE.log
 DOCKER_OPTS=
 DOCKER_DESC="Docker"
@@ -83,11 +89,19 @@ case "$1" in
     touch "$DOCKER_LOGFILE"
     chgrp docker "$DOCKER_LOGFILE"
 
+    ulimit -n 1048576
+    if [ "$BASH" ]; then
+      ulimit -u 1048576
+    else
+      ulimit -p 1048576
+    fi
+
     log_begin_msg "Starting $DOCKER_DESC: $BASE"
     start-stop-daemon --start --background \
       --no-close \
       --exec "$DOCKER" \
-      --pidfile "$DOCKER_PIDFILE" \
+      --pidfile "$DOCKER_SSD_PIDFILE" \
+      --make-pidfile \
       -- \
         -d -p "$DOCKER_PIDFILE" \
         $DOCKER_OPTS \
@@ -98,13 +112,13 @@ case "$1" in
   stop)
     fail_unless_root
     log_begin_msg "Stopping $DOCKER_DESC: $BASE"
-    start-stop-daemon --stop --pidfile "$DOCKER_PIDFILE"
+    start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE"
     log_end_msg $?
     ;;
 
   restart)
     fail_unless_root
-    docker_pid=`cat "$DOCKER_PIDFILE" 2>/dev/null`
+    docker_pid=`cat "$DOCKER_SSD_PIDFILE" 2>/dev/null`
     [ -n "$docker_pid" ] \
       && ps -p $docker_pid > /dev/null 2>&1 \
       && $0 stop
@@ -117,7 +131,7 @@ case "$1" in
     ;;
 
   status)
-    status_of_proc -p "$DOCKER_PIDFILE" "$DOCKER" docker
+    status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" "$DOCKER_DESC"
     ;;
 
   *)

--- a/templates/default/docker.sysv.erb
+++ b/templates/default/docker.sysv.erb
@@ -24,6 +24,7 @@
 
 exec="<%= Docker::Helpers.executable(node) %>"
 prog="docker"
+unshare=/usr/bin/unshare
 <% if node['docker']['pidfile'] -%>
 pidfile="<%= node['docker']['pidfile'] %>"
 <% else -%>
@@ -58,11 +59,13 @@ prestart() {
 start() {
     [ -x $exec ] || exit 5
 
+    check_for_cleanup
+
     if ! [ -f $pidfile ]; then
         prestart
         printf "Starting $prog:\t"
         echo "\n$(date)\n" >> $logfile
-        $exec -d $DOCKER_OPTS &>> $logfile &
+        "$unshare" -m -- $exec -d $DOCKER_OPTS &>> $logfile &
         pid=$!
         touch $lockfile
         # wait up to 10 seconds for the pidfile to exist.  see
@@ -84,7 +87,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc -p $pidfile $prog
+    killproc -p $pidfile -d 300 $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile
@@ -110,6 +113,12 @@ rh_status() {
 
 rh_status_q() {
     rh_status >/dev/null 2>&1
+}
+
+check_for_cleanup() {
+    if [ -f ${pidfile} ]; then
+        /bin/ps -fp $(cat ${pidfile}) > /dev/null || rm ${pidfile}
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
Non-Debian SysV changes to match upstream:
* `check_for_cleanup`: https://github.com/docker/docker/commit/05d04843e6b80f131c07882c882f7e4da018a306
* `killproc -d 300`: https://github.com/docker/docker/commit/640d2ef6f54d96ac4fc3f0f745cb1e6a35148607
* `unshare`: https://github.com/docker/docker/commit/6bb65864589fbd720622cbd795763d108999a366
  * part of `util-linux-ng` package, installed on almost all CentOS/RHEL 6+ boxes by default

Debian SysV changes to match upstream:
* `DOCKER_SSD_PIDFILE`: https://github.com/docker/docker/commit/c11fadb282ea7e96eef2280a5e422fd2c94e8c45
* `set -e` / `status_of_proc $DOCKER_DESC`: https://github.com/docker/docker/commit/478fdaf93353c70a26c0043dadb650fd2f101c40
* `Should-Start` / `Should-Stop`: https://github.com/docker/docker/commit/36d913078b7ea0138dbc5d561703d068e7e31934
* `ulimit`: https://github.com/docker/docker/commit/bae79c3e7285c170f97a0f7f331a48fb47f0f40e and https://github.com/docker/docker/commit/4f0fbb885eb6b561fd6e4ba26b35cb30dd8d9121
