### PR TITLE
Fixed remaining `-notrunc` usages

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -230,7 +230,7 @@ def get_ranges(header)
 end
 
 #
-# Get a list of all docker containers by parsing the output of `docker ps -a -notrunc`.
+# Get a list of all docker containers by parsing the output of `docker ps -a --no-trunc`.
 #
 # Uses `get_ranges` to determine where column data is within each row. Then, for each line after
 # the header, a hash is build up with the values for each of the columns. A special 'line' entry

--- a/templates/default/docker-container.sysv.erb
+++ b/templates/default/docker-container.sysv.erb
@@ -71,7 +71,7 @@ force_reload() {
 }
 
 status() {
-    $exec ps -a -notrunc | grep $prog | grep -qc "Up"
+    $exec ps -a --no-trunc | grep $prog | grep -qc "Up"
 }
 
 case "$1" in

--- a/test/cookbooks/docker_test/files/default/tests/minitest/support/helpers.rb
+++ b/test/cookbooks/docker_test/files/default/tests/minitest/support/helpers.rb
@@ -9,13 +9,13 @@ module Helpers
     include MiniTest::Chef::Resources
 
     def container_exists?(image, command = nil)
-      dps = shell_out("docker ps -a -notrunc")
+      dps = shell_out("docker ps -a --no-trunc")
       return dps.stdout.include?(command) if command
       dps.stdout.include?(image)
     end
 
     def container_running?(image, command = nil)
-      dps = shell_out("docker ps -a -notrunc")
+      dps = shell_out("docker ps -a --no-trunc")
       dps.stdout.each_line do |dps_line|
         if command
           return dps_line.include?("Up") if dps_line.include?(command)


### PR DESCRIPTION
The `-notrunc` flag causes a very annoying warning message to stderr.

This replaces the last usage (sysv init file), a comment, and the
minitests.