### PR TITLE
amazon init.d template was not using DOCKER_OPTS

### DIFF
--- a/templates/amazon/docker.sysv.erb
+++ b/templates/amazon/docker.sysv.erb
@@ -30,6 +30,8 @@ logfile="/var/log/$prog"
 
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
 
+DOCKER_OPTS="${DOCKER_OPTS:-${other_args}}"
+
 prestart() {
   service cgconfig status > /dev/null
 
@@ -46,7 +48,7 @@ start() {
     prestart
     printf "Starting $prog:\t"
     echo "\n$(date)\n" >> $logfile
-    nohup $exec -d $other_args &>> $logfile &
+    nohup $exec -d ${DOCKER_OPTS} &>> $logfile &
     pid=$!
     sleep 1
     touch $lockfile


### PR DESCRIPTION
I know this isn't tied to an existing issue at the moment. I discovered an issue where daemon options passed into the docker recipes are not honored when installed. This appears to have been caused by the init.d script used specifically for Amazon not pointing to the DOCKER_OPTS variable even though that variable was being written correctly.