### PR TITLE
init.d script in amazon did not reference DOCKER_OPTS

### DIFF
--- a/templates/amazon/docker.sysv.erb
+++ b/templates/amazon/docker.sysv.erb
@@ -30,6 +30,8 @@ logfile="/var/log/$prog"
 
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
 
+DOCKER_OPTS="${DOCKER_OPTS:-${other_args}}"
+
 prestart() {
   service cgconfig status > /dev/null
 
@@ -46,7 +48,7 @@ start() {
     prestart
     printf "Starting $prog:\t"
     echo "\n$(date)\n" >> $logfile
-    nohup $exec -d $other_args &>> $logfile &
+    nohup $exec -d ${DOCKER_OPTS} &>> $logfile &
     pid=$!
     sleep 1
     touch $lockfile


### PR DESCRIPTION
DOCKER_OPTS was not being honored during startup of docker on Amazon
Linux. The init.d script was not referencing the correct file.