### PR TITLE
removed --no-trunc from docker container status

### DIFF
--- a/templates/default/docker-container.sysv.erb
+++ b/templates/default/docker-container.sysv.erb
@@ -71,7 +71,7 @@ force_reload() {
 }
 
 status() {
-    $exec ps -a --no-trunc | grep $prog | grep -qc "Up"
+    $exec ps -a | grep $prog | grep -qc "Up"
 }
 
 case "$1" in


### PR DESCRIPTION
in recent version of docker, --no-trunc includes extra information about
links to other containers. This caused the ps command used for status to
return more than one container in certain cases. This is a fix for issue #323 