### PR TITLE
Adds support for HTTPS_PROXY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ graph | Path to use as the root of the docker runtime | String | nil (implicitly
 group | Group for docker socket and group_members | String | nil (implicitly docker)
 host | Socket(s) that docker should bind | String, Array | unix:///var/run/docker.sock
 http_proxy | HTTP_PROXY environment variable | String | nil
+https_proxy | HTTPS_PROXY environment variable | String | nil
 icc | Enable inter-container communication | TrueClass, FalseClass | nil (implicitly true)
 insecure-registry | List of well-known insecure registries | String, Array | nil
 ip | Default IP address to use when binding container ports | String | nil (implicitly 0.0.0.0)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -156,6 +156,7 @@ default['docker']['host'] =
     'unix:///var/run/docker.sock'
   end
 default['docker']['http_proxy'] = nil
+default['docker']['https_proxy'] = nil
 default['docker']['icc'] = nil
 default['docker']['insecure-registry'] = nil
 default['docker']['ip'] = nil

--- a/spec/systemd_spec.rb
+++ b/spec/systemd_spec.rb
@@ -244,6 +244,19 @@ describe 'docker::systemd' do
     end
   end
 
+  context 'when https_proxy is set' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new
+      runner.node.set['docker']['https_proxy'] = 'http://username:password@proxy.example.com:8080'
+      runner.converge(described_recipe)
+    end
+
+    it 'sets HTTPS_PROXY environment variable in docker service' do
+      expect(chef_run).to render_file('/usr/lib/systemd/system/docker.service').with_content(
+        %r{^Environment="HTTPS_PROXY=http://username:password@proxy.example.com:8080"$})
+    end
+  end
+
   context 'when no_proxy is set' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new

--- a/spec/sysv_spec.rb
+++ b/spec/sysv_spec.rb
@@ -255,6 +255,19 @@ describe 'docker::sysv' do
     end
   end
 
+  context 'when https_proxy is set' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new
+      runner.node.set['docker']['https_proxy'] = 'http://username:password@proxy.example.com:8080'
+      runner.converge(described_recipe)
+    end
+
+    it 'sets HTTPS_PROXY environment variable in docker service' do
+      expect(chef_run).to render_file('/etc/default/docker').with_content(
+        %r{^export HTTPS_PROXY=http://username:password@proxy.example.com:8080$})
+    end
+  end
+
   context 'when no_proxy is set' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new

--- a/spec/upstart_spec.rb
+++ b/spec/upstart_spec.rb
@@ -256,6 +256,19 @@ describe 'docker::upstart' do
     end
   end
 
+  context 'when https_proxy is set' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new
+      runner.node.set['docker']['https_proxy'] = 'http://username:password@proxy.example.com:8080'
+      runner.converge(described_recipe)
+    end
+
+    it 'sets HTTPS_PROXY environment variable in docker service' do
+      expect(chef_run).to render_file('/etc/default/docker').with_content(
+        %r{^export HTTPS_PROXY=http://username:password@proxy.example.com:8080$})
+    end
+  end
+
   context 'when no_proxy is set' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new

--- a/templates/default/docker.service.erb
+++ b/templates/default/docker.service.erb
@@ -12,6 +12,9 @@ Environment="DOCKER_RAMDISK=<%= node['docker']['ramdisk'] %>"
 <% if node['docker']['http_proxy'] -%>
 Environment="HTTP_PROXY=<%= node['docker']['http_proxy'] %>"
 <% end -%>
+<% if node['docker']['https_proxy'] -%>
+Environment="HTTPS_PROXY=<%= node['docker']['https_proxy'] %>"
+<% end -%>
 <% if node['docker']['no_proxy'] -%>
 Environment="NO_PROXY=<%= node['docker']['no_proxy'] %>"
 <% end -%>

--- a/templates/default/docker.sysconfig.erb
+++ b/templates/default/docker.sysconfig.erb
@@ -22,6 +22,9 @@ DOCKER_RAMDISK=<%= node['docker']['ramdisk'] %>
 <% if node['docker']['http_proxy'] -%>
 export HTTP_PROXY=<%= node['docker']['http_proxy'] %>
 <% end -%>
+<% if node['docker']['https_proxy'] -%>
+export HTTPS_PROXY=<%= node['docker']['https_proxy'] %>
+<% end -%>
 <% if node['docker']['no_proxy'] -%>
 export NO_PROXY=<%= node['docker']['no_proxy'] %>
 <% end -%>

--- a/templates/default/sv-docker-run.erb
+++ b/templates/default/sv-docker-run.erb
@@ -6,6 +6,9 @@ export DOCKER_RAMDISK=<%= node['docker']['ramdisk'] %>
 <% if node['docker']['http_proxy'] -%>
 export HTTP_PROXY=<%= node['docker']['http_proxy'] %>
 <% end -%>
+<% if node['docker']['https_proxy'] -%>
+export HTTPS_PROXY=<%= node['docker']['https_proxy'] %>
+<% end -%>
 <% if node['docker']['no_proxy'] -%>
 export NO_PROXY=<%= node['docker']['no_proxy'] %>
 <% end -%>


### PR DESCRIPTION
Adds `HTTPS_PROXY` environment variable to Docker settings when `node['docker']['https_proxy']` is present.

Fixes #222 