### PR TITLE
Add ulimit attribute back to container resource

### DIFF
--- a/resources/container.rb
+++ b/resources/container.rb
@@ -56,6 +56,7 @@ attribute :status, kind_of: String
 attribute :stdin, kind_of: [TrueClass, FalseClass]
 attribute :tag, kind_of: String
 attribute :tty, kind_of: [TrueClass, FalseClass]
+attribute :ulimit, kind_of: [String, Array]
 attribute :user, kind_of: String
 attribute :volume, kind_of: [String, Array]
 attribute :volumes_from, kind_of: String


### PR DESCRIPTION
This attribute was removed in [28217e](https://github.com/bflad/chef-docker/commit/28217e99f402c4fa716f2164985fc1cdf145b6aa#diff-b0b27265fc5f4128b47410ecb3085361L60) but is still used in the corresponding [provider](https://github.com/bflad/chef-docker/blob/master/providers/container.rb#L392). I'm assuming its removal was unintentional.

Its absence is causing a NoMethodError:

```
....
       ================================================================================
           Error executing action `run` on resource 'docker_container[consul]'
           ================================================================================

           NoMethodError
           -------------
           undefined method `ulimit' for LWRP resource docker_container from cookbook docker
...
```