### PR TITLE
Declare ulimit parameter in the resource

### DIFF
--- a/resources/container.rb
+++ b/resources/container.rb
@@ -56,6 +56,7 @@ attribute :status, kind_of: String
 attribute :stdin, kind_of: [TrueClass, FalseClass]
 attribute :tag, kind_of: String
 attribute :tty, kind_of: [TrueClass, FalseClass]
+attribute :ulimit, kind_of: [String, Array]
 attribute :user, kind_of: String
 attribute :volume, kind_of: [String, Array]
 attribute :volumes_from, kind_of: String


### PR DESCRIPTION
With v0.40.0, I got the following error:

```
NoMethodError: undefined method `ulimit' for LWRP resource docker_container from cookbook docker
```