### PR TITLE
Fixes #320 - ability to specify a tag for a container image

### DIFF
--- a/providers/container.rb
+++ b/providers/container.rb
@@ -352,7 +352,7 @@ end
 
 def run
   run_args = cli_args(run_cli_args)
-  dr = docker_cmd!("run #{run_args} #{new_resource.image} #{new_resource.command}")
+  dr = docker_cmd!("run #{run_args} #{new_resource.image}:#{new_resource.tag} #{new_resource.command}")
   dr.error!
   new_resource.id(dr.stdout.chomp)
   service_run if service?

--- a/resources/container.rb
+++ b/resources/container.rb
@@ -54,7 +54,7 @@ attribute :socket_template, kind_of: String
 attribute :source, kind_of: String
 attribute :status, kind_of: String
 attribute :stdin, kind_of: [TrueClass, FalseClass]
-attribute :tag, kind_of: String
+attribute :tag, kind_of: String, default: 'latest'
 attribute :tty, kind_of: [TrueClass, FalseClass]
 attribute :user, kind_of: String
 attribute :volume, kind_of: [String, Array]


### PR DESCRIPTION
As per https://github.com/bflad/chef-docker/issues/320 - the container resource wasn't allowing tag overrides. I've set the tag to default to "latest" and allowed this to be overridden.