### PR TITLE
[GH-340] - Added support and default to docker engine 1.7.1 binary.

### DIFF
--- a/libraries/helpers-new.rb
+++ b/libraries/helpers-new.rb
@@ -49,12 +49,14 @@ module DockerHelpers
       when '1.6.0' then '9e960e925561b4ec2b81f52b6151cd129739c1f4fba91ce94bdc0333d7d98c38'
       when '1.6.2' then 'f29b8b2185c291bd276f7cdac45a674f904e964426d5b969fda7b8ef6b8ab557'
       when '1.7.0' then '1c8ee59249fdde401afebc9a079cb75d7674f03d2491789fb45c88020a8c5783'
+      when '1.7.1' then 'b8209b4382d0b4292c756dd055c12e5efacec2055d5900ac91efc8e81d317cf9'
       end
     when 'Linux'
       case parsed_version
       when '1.6.0' then '526fbd15dc6bcf2f24f99959d998d080136e290bbb017624a5a3821b63916ae8'
       when '1.6.2' then 'e131b2d78d9f9e51b0e5ca8df632ac0a1d48bcba92036d0c839e371d6cf960ec'
       when '1.7.0' then 'a27669f3409f5889cb86e6d9e7914d831788a9d96c12ecabb24472a6cd7b1007'
+      when '1.7.1' then '4d535a62882f2123fb9545a5d140a6a2ccc7bfc7a3c0ec5361d33e498e4876d5'
       end
     end
   end
@@ -66,7 +68,7 @@ module DockerHelpers
 
   def parsed_version
     return new_resource.version if new_resource.version
-    '1.6.2'
+    '1.7.1'
   end
 
   def parsed_source


### PR DESCRIPTION
* added support for 1.7.1 (with checksums) in helpers-new.rb parse_version()
* change default to 1.7.1 in helpers-new.rb parsed_version()

Docker Engine 1.7.1 Changelog:
https://github.com/docker/docker/blob/v1.7.1/CHANGELOG.md