### PR TITLE
The --dns-search argument appears multiple times

### DIFF
--- a/libraries/helpers-new.rb
+++ b/libraries/helpers-new.rb
@@ -103,7 +103,11 @@ module DockerHelpers
     opts << ' --debug' if new_resource.debug
     opts << " --default-ulimit=#{new_resource.default_ulimit}" if new_resource.default_ulimit
     opts << " --dns=#{new_resource.dns}" if new_resource.dns
-    opts << " --dns-search=#{new_resource.dns_search}" if new_resource.dns_search
+    if new_resource.dns_search
+      new_resource.dns_search.each do |dns_search|
+        opts << " --dns-search=#{dns_search}"
+      end
+    end
     opts << " --exec-driver=#{new_resource.exec_driver}" if new_resource.exec_driver
     opts << " --fixed-cidr=#{new_resource.fixed_cidr}" if new_resource.fixed_cidr
     opts << " --fixed-cidr-v6=#{new_resource.fixed_cidr_v6}" if new_resource.fixed_cidr_v6


### PR DESCRIPTION
Before the code would output a Ruby Array in the Array syntax, so something like:

```
docker -d ... --dns-search=["custom.domain.com"] ...
```

The Array delimiters wasn't the [right format for the --dns-search argument](https://docs.docker.com/articles/networking/#dns) and the docker daemon would not start correctly. The daemon expects the --dns-search argument once per domain.

I've tested this on a local test-kitchen run in our wrapper cookbook and the daemon starts correctly :smile: 