### PR TITLE
Use docker_kernel instead of docker_arch in parsed_checksum

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -43,7 +43,7 @@ module DockerHelpers
   end
 
   def parsed_checksum
-    case docker_arch
+    case docker_kernel
     when 'Darwin'
       case parsed_version
       when '1.6.0' then '9e960e925561b4ec2b81f52b6151cd129739c1f4fba91ce94bdc0333d7d98c38'

--- a/spec/docker_service_test/socket_spec.rb
+++ b/spec/docker_service_test/socket_spec.rb
@@ -5,7 +5,7 @@ describe 'docker_service_test::socket on centos-7.0' do
     ChefSpec::SoloRunner.new(
       platform: 'centos',
       version: '7.0',
-    # step_into: 'docker_service'
+      step_into: 'docker_service'
     ) do |node|
       node.set['docker']['version'] = nil
     end.converge('docker_service_test::socket')
@@ -15,6 +15,19 @@ describe 'docker_service_test::socket on centos-7.0' do
   context 'compiling the test recipe' do
     it 'creates docker_service[default]' do
       expect(default).to create_docker_service('default')
+    end
+  end
+
+  context 'stepping into docker_service[default] resource' do
+    it 'creates remote_file[/usr/bin/docker]' do
+      expect(default).to create_remote_file('/usr/bin/docker')
+        .with(
+          source: 'http://get.docker.io/builds/Linux/x86_64/docker-1.8.1',
+          checksum: '843f90f5001e87d639df82441342e6d4c53886c65f72a5cc4765a7ba3ad4fc57',
+          owner: 'root',
+          group: 'root',
+          mode: '0755'
+        )
     end
   end
 end


### PR DESCRIPTION
I noticed this bug while I was reading through the code so I figured I'd send a patch with a test.