### PR TITLE
allow port to be a kind_of array

### DIFF
--- a/libraries/resource_docker_container.rb
+++ b/libraries/resource_docker_container.rb
@@ -39,7 +39,7 @@ class Chef
       attribute :network_mode, kind_of: String, default: ''
       attribute :open_stdin, kind_of: [TrueClass, FalseClass], default: false
       attribute :outfile, kind_of: String, default: nil
-      attribute :port, kind_of: String, default: ''
+      attribute :port, kind_of: [String, Array], default: ''
       attribute :privileged, kind_of: [TrueClass, FalseClass], default: false
       attribute :publish_all_ports, kind_of: [TrueClass, FalseClass], default: false
       attribute :remove_volumes, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
PR #363 allows port to be an array but the resource attribute restricts only to a string.