### PR TITLE
Supermarket should display source and issues links

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,9 @@ description 'Installs/Configures Docker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.0.4'
 
+source_url 'https://github.com/bflad/chef-docker'
+issues_url 'https://github.com/bflad/chef-docker/issues'
+
 supports 'amazon'
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
Add the `source_url` and `issues_url` keys to the metadata