### PR TITLE
Fix 'parsed_storage_driver' method error

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -108,7 +108,7 @@ module DockerHelpers
   end
 
   def parsed_storage_driver
-    Array(storage_driver)
+    Array(new_resource.storage_driver)
   end
 
   def docker_opts


### PR DESCRIPTION
```
[2015-08-23T22:20:17+00:00] ERROR: docker_service[default] (scalingo::docker line 12) had an error: NameError: No resource, method, or local variable named `storage_driver' for `Chef::Provider::DockerService::Upstart ""'
```