### PR TITLE
Correctly define ip_forward flag, not present by default in opts

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -129,7 +129,7 @@ module DockerHelpers
     opts << '--icc=true' if new_resource.icc
     opts << "--insecure-registry=#{new_resource.insecure_registry}" if new_resource.insecure_registry
     opts << "--ip=#{new_resource.ip}" if new_resource.ip
-    opts << '--ip-forward=true' if new_resource.ip_forward
+    opts << "--ip-forward=#{new_resource.ip_forward}" unless new_resource.ip_forward.nil?
     opts << '--ip-masq=true' if new_resource.ip_masq
     opts << '--iptables=true' if new_resource.iptables
     opts << '--ipv6=true' if new_resource.ipv6

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -36,7 +36,7 @@ class Chef
       attribute :icc, kind_of: [TrueClass, FalseClass], default: nil
       attribute :insecure_registry, kind_of: String, default: nil
       attribute :ip, kind_of: String, regex: [IPV4_ADDR, IPV6_ADDR], default: nil
-      attribute :ip_forward, kind_of: [TrueClass, FalseClass], default: true
+      attribute :ip_forward, kind_of: [TrueClass, FalseClass], default: nil
       attribute :ipv4_forward, kind_of: [TrueClass, FalseClass], default: true
       attribute :ipv6_forward, kind_of: [TrueClass, FalseClass], default: true
       attribute :ip_masq, kind_of: [TrueClass, FalseClass], default: nil


### PR DESCRIPTION
As it is defined to be a boolean in the resource, the only possible
values allowed to the user are true or false. Let docker use its default
value instead of setting a default flag.

If the user knows what he's doing he'll be able to give a specific value
to the flag.