### PR TITLE
GH-395 Check if platform_family matches rhel, rather than redhat, in Sysvinit

### DIFF
--- a/libraries/provider_docker_service_sysvinit.rb
+++ b/libraries/provider_docker_service_sysvinit.rb
@@ -27,8 +27,8 @@ class Chef
           end
 
           service 'docker' do
-            provider Chef::Provider::Service::Init::Redhat if node['platform_family'] == 'redhat'
-            provider Chef::Provider::Service::Init::Insserv if node['platform_family'] == 'debian'
+            provider Chef::Provider::Service::Init::Redhat if platform_family?('rhel')
+            provider Chef::Provider::Service::Init::Insserv if platform_family?('debian')
             supports restart: true, status: true
             action [:enable, :start]
           end
@@ -36,8 +36,8 @@ class Chef
 
         action :stop do
           service 'docker' do
-            provider Chef::Provider::Service::Init::Redhat if node['platform_family'] == 'redhat'
-            provider Chef::Provider::Service::Init::Insserv if node['platform_family'] == 'debian'
+            provider Chef::Provider::Service::Init::Redhat if platform_family?('rhel')
+            provider Chef::Provider::Service::Init::Insserv if platform_family?('debian')
             supports restart: true, status: true
             action [:stop]
           end
@@ -45,8 +45,8 @@ class Chef
 
         action :restart do
           service 'docker' do
-            provider Chef::Provider::Service::Init::Redhat if node['platform_family'] == 'redhat'
-            provider Chef::Provider::Service::Init::Insserv if node['platform_family'] == 'debian'
+            provider Chef::Provider::Service::Init::Redhat if platform_family?('rhel')
+            provider Chef::Provider::Service::Init::Insserv if platform_family?('debian')
             action :reload
           end
         end

--- a/spec/docker_service_test/sysvinit_spec.rb
+++ b/spec/docker_service_test/sysvinit_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'Chef::Provider::DockerService::Sysvinit with Centos' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'centos',
+      version: '7.0',
+      step_into: 'docker_service'
+    ).converge('docker_service_test::sysvinit')
+  end
+
+  it 'creates docker_service[default]' do
+    expect(chef_run).to create_docker_service('default')
+  end
+
+  it 'creates the sysvinit file' do
+    expect(chef_run).to render_file('/etc/init.d/docker')
+  end
+end

--- a/test/cookbooks/docker_service_test/recipes/sysvinit.rb
+++ b/test/cookbooks/docker_service_test/recipes/sysvinit.rb
@@ -1,0 +1,4 @@
+docker_service 'default' do
+  provider Chef::Provider::DockerService::Sysvinit
+  action [:create, :start]
+end


### PR DESCRIPTION
node['platform'] returns a specific flavor of rhel (like Redhat, Centos, etc), whereas node['platform_family'] is more general, returning 'rhel' for both Redhat and Centos. I updated the sysvinit provider to reflect this.

Also added a couple of tests for Chef::Provider::DockerService::Sysvinit on a Centos7 box.