### PR TITLE
adding ability to set docker api read write timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,14 @@ docker_image 'alpine' do
 end
 ```
 
+specify read/write timeouts
+```ruby
+docker_image 'alpine' do
+  read_timeout 60
+  write_timeout 60
+end
+```
+
 ```ruby
 docker_image 'vbatts/slackware' do
   action :remove
@@ -392,11 +400,13 @@ registry vs a private one.
   Dockerfile. For import, this should be a tarball containing Docker
   formatted image, as generated with `:save`.
 - `destination` - Path for output from the `:save` action.
-- `force` A force boolean used in various actions - Defaults to false
+- `force` - A force boolean used in various actions - Defaults to false
 - `nocache` - Used in `:build` operations. - Defaults to false
 - `noprune` - Used in `:remove` operations - Defaults to false
 - `rm` - Remove intermediate containers after a successful build
   (default behavior) - Defaults to `true`
+- `read_timeout` - May need to increase for long image builds/pulls
+- `write_timeout` - May need to increase for long image builds/pulls
 
 #### Actions
 The following actions are available for a `docker_image` resource.
@@ -787,6 +797,16 @@ execute 'commit mutator' do
 end
 ```
 
+Specify read/write timeouts
+
+```ruby
+docker_container 'api_timeouts' do
+  repo 'alpine'
+  read_timeout 60
+  write_timeout 60
+end
+```
+
 #### Properties
 
 Most `docker_container` properties are the `snake_case` version of the
@@ -868,6 +888,8 @@ Most `docker_container` properties are the `snake_case` version of the
   container. Specified in the form `<container name>[:<ro|rw>]`
 - `working_dir` - A string specifying the working directory for
   commands to run in.
+- `read_timeout` - May need to increase for commits or exports that are slow
+- `write_timeout` - May need to increase for commits or exports that are slow
 
 #### Actions
 

--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -12,6 +12,11 @@ class Chef
       # Helper methods
       ################
 
+      def api_timeouts
+        Docker.options[:read_timeout] = new_resource.read_timeout unless new_resource.read_timeout.nil?
+        Docker.options[:write_timeout] = new_resource.write_timeout unless new_resource.write_timeout.nil?
+      end
+
       # This is called a lot.. maybe this should turn into an instance variable
       def container_created?
         Docker::Container.get(new_resource.container_name)
@@ -128,6 +133,7 @@ class Chef
 
       # Most important work is done here.
       def create_container
+        api_timeouts
         tries ||= new_resource.api_retries
         Docker::Container.create(
           'name' => new_resource.container_name,
@@ -194,6 +200,7 @@ class Chef
       end
 
       action :start do
+        api_timeouts
         c = Docker::Container.get(new_resource.container_name)
         next if c.info['State']['Restarting']
         next if c.info['State']['Running']
@@ -221,6 +228,7 @@ class Chef
       end
 
       action :stop do
+        api_timeouts
         next unless container_created?
         c = Docker::Container.get(new_resource.container_name)
         next unless c.info['State']['Running']
@@ -237,6 +245,7 @@ class Chef
       end
 
       action :kill do
+        api_timeouts
         next unless container_created?
         c = Docker::Container.get(new_resource.container_name)
         next unless c.info['State']['Running']
@@ -264,6 +273,7 @@ class Chef
       end
 
       action :pause do
+        api_timeouts
         next unless container_created?
         c = Docker::Container.get(new_resource.container_name)
         next if c.info['State']['Paused']
@@ -280,6 +290,7 @@ class Chef
       end
 
       action :unpause do
+        api_timeouts
         next unless container_created?
         c = Docker::Container.get(new_resource.container_name)
         next unless c.info['State']['Paused']
@@ -337,6 +348,7 @@ class Chef
       end
 
       action :commit do
+        api_timeouts
         c = Docker::Container.get(new_resource.container_name)
         converge_by "committing #{new_resource.container_name}" do
           begin
@@ -351,6 +363,7 @@ class Chef
       end
 
       action :export do
+        api_timeouts
         fail "Please set outfile property on #{new_resource.container_name}" if new_resource.outfile.nil?
         c = Docker::Container.get(new_resource.container_name)
         converge_by "exporting #{new_resource.container_name}" do

--- a/libraries/provider_docker_image.rb
+++ b/libraries/provider_docker_image.rb
@@ -11,6 +11,11 @@ class Chef
       # Helper methods
       ################
 
+      def api_timeouts
+        Docker.options[:read_timeout] = new_resource.read_timeout unless new_resource.read_timeout.nil?
+        Docker.options[:write_timeout] = new_resource.write_timeout unless new_resource.write_timeout.nil?
+      end
+
       def build_from_directory
         i = Docker::Image.build_from_dir(
           new_resource.source,
@@ -39,6 +44,7 @@ class Chef
       end
 
       def build_image
+        api_timeouts
         if ::File.directory?(new_resource.source)
           build_from_directory
         elsif ::File.extname(new_resource.source) == '.tar'
@@ -53,6 +59,7 @@ class Chef
       end
 
       def import_image
+        api_timeouts
         retries ||= new_resource.api_retries
         i = Docker::Image.import(new_resource.source)
         i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
@@ -62,6 +69,7 @@ class Chef
       end
 
       def pull_image
+        api_timeouts
         retries ||= new_resource.api_retries
         o = Docker::Image.get(image_identifier) if Docker::Image.exist?(image_identifier)
         i = Docker::Image.create(
@@ -76,6 +84,7 @@ class Chef
       end
 
       def push_image
+        api_timeouts
         retries ||= new_resource.api_retries
         i = Docker::Image.get(image_identifier)
         i.push
@@ -85,6 +94,7 @@ class Chef
       end
 
       def remove_image
+        api_timeouts
         retries ||= new_resource.api_retries
         i = Docker::Image.get(image_identifier)
         i.remove(force: new_resource.force, noprune: new_resource.noprune)
@@ -94,6 +104,7 @@ class Chef
       end
 
       def save_image
+        api_timeouts
         retries ||= new_resource.api_retries
         Docker::Image.save(new_resource.repo, new_resource.destination)
       rescue Docker::Error, Errno::ENOENT => e

--- a/libraries/resource_docker_container.rb
+++ b/libraries/resource_docker_container.rb
@@ -44,6 +44,7 @@ class Chef
       attribute :port, kind_of: [String, Array], default: ''
       attribute :privileged, kind_of: [TrueClass, FalseClass], default: false
       attribute :publish_all_ports, kind_of: [TrueClass, FalseClass], default: false
+      attribute :read_timeout, kind_of: [Fixnum, NilClass], default: nil
       attribute :remove_volumes, kind_of: [TrueClass, FalseClass], default: false
       attribute :restart_maximum_retry_count, kind_of: Fixnum, default: 0
       attribute :restart_policy, equal_to: %w(no on-failure always), default: 'no'
@@ -57,6 +58,7 @@ class Chef
       attribute :volumes, kind_of: [String, Array, NilClass], default: '' # FIXME: add validate proc
       attribute :volumes_from, kind_of: [String, Array, NilClass], default: nil # FIXME: add validate proc
       attribute :working_dir, kind_of: String, default: ''
+      attribute :write_timeout, kind_of: [Fixnum, NilClass], default: nil
 
       alias_method :cmd, :command
       alias_method :image, :repo

--- a/libraries/resource_docker_image.rb
+++ b/libraries/resource_docker_image.rb
@@ -15,10 +15,12 @@ class Chef
       attribute :force, kind_of: [TrueClass, FalseClass], default: false
       attribute :nocache, kind_of: [TrueClass, FalseClass], default: false
       attribute :noprune, kind_of: [TrueClass, FalseClass], default: false
+      attribute :read_timeout, kind_of: [Fixnum, NilClass], default: nil
       attribute :repo, kind_of: String, name_attribute: true
       attribute :rm, kind_of: [TrueClass, FalseClass], default: true
       attribute :source, kind_of: String
       attribute :tag, kind_of: String, default: 'latest'
+      attribute :write_timeout, kind_of: [Fixnum, NilClass], default: nil
 
       alias_method :image, :repo
       alias_method :image_name, :repo

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -749,3 +749,13 @@ docker_container 'ulimits' do
   ]
   action :run
 end
+
+##############
+# api_timeouts
+##############
+
+docker_container 'api_timeouts' do
+  repo 'alpine'
+  read_timeout 60
+  write_timeout 60
+end

--- a/test/cookbooks/docker_test/recipes/image.rb
+++ b/test/cookbooks/docker_test/recipes/image.rb
@@ -25,6 +25,12 @@ docker_image 'alpine' do
   tag '3.1'
 end
 
+# specify read/write timeouts
+docker_image 'alpine' do
+  read_timeout 60
+  write_timeout 60
+end
+
 #########
 # :remove
 #########


### PR DESCRIPTION
i split the api timeouts into two attributes matching the docker api. not sure if you want to combine this into one attrib or not, if you do let me know and i can change it.

resolves #403