### PR TITLE
`parsed_checksum` helper for docker_service returns new_resource.checksum if specified

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -47,6 +47,7 @@ module DockerHelpers
   end
 
   def parsed_checksum
+    return new_resource.checksum if new_resource.checksum
     case docker_kernel
     when 'Darwin'
       case parsed_version


### PR DESCRIPTION
If a user wanted to use the `source` attribute for the `docker_service` LWRP they need to specify a custom `checksum` attribute as well. The `parsed_checksum` helper method was ignoring this custom attribute and always providing the LWRP with a hard-coded checksum which matched with the default docker binary source.