### PR TITLE
Change storage_opt attrib to storage_opts in docker_service LWRP

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -145,7 +145,7 @@ module DockerHelpers
     opts << "--registry-mirror=#{new_resource.registry_mirror}" if new_resource.registry_mirror
     parsed_storage_driver.each { |s| opts << "--storage-driver=#{s}" } if new_resource.storage_driver
     opts << '--selinux-enabled=true' if new_resource.selinux_enabled
-    opts << "--storage-opt=#{new_resource.storage_opt}" if new_resource.storage_opt
+    new_resource.storage_opts.each { |storage_opt| opts << "--storage-opt=#{storage_opt}" }
     opts << '--tls=true' if new_resource.tls
     opts << "--tlscacert=#{new_resource.tlscacert}" if new_resource.tlscacert
     opts << "--tlscert=#{new_resource.tlscert}" if new_resource.tlscert

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -50,7 +50,7 @@ class Chef
       attribute :registry_mirror, kind_of: String, default: nil
       attribute :storage_driver, kind_of: [String, Array], default: nil
       attribute :selinux_enabled, kind_of: [TrueClass, FalseClass], default: nil
-      attribute :storage_opt, kind_of: String, default: nil
+      attribute :storage_opts, kind_of: Array, default: []
       attribute :tls, kind_of: [TrueClass, FalseClass], default: false
       attribute :tlscacert, kind_of: String, default: nil
       attribute :tlscert, kind_of: String, default: nil


### PR DESCRIPTION
Currently if the `storage_opt` attribute for docker_service is
specified on the docker_service resource it's value will be passed
to the docker daemon prefixed by a single `--storage-opt` flag.

Each storage option passed to the docker daemon requires being
prefixed with it's own `--storage-opt` flag. Because of this
prefixing the value of `storage_opt` with a single `--storage-opt`
flag is a bug, as it makes passing multipe storage options to
the docker daemon hard to accomplish.

To correct this I've replaces the `storage_opt` attribute for
docker_service with `storage_opts` and accept an Array. Then in
the `docker_opts` helper method I collect the value of the array
and prefix each item with it's own `--storage-opt` flag.