### PR TITLE
GH-398 Raise AuthenticationError if number of retries on login is exceeded

### DIFF
--- a/libraries/provider_docker_registry.rb
+++ b/libraries/provider_docker_registry.rb
@@ -16,7 +16,11 @@ class Chef
             'email' => new_resource.email
           )
         rescue Docker::Error::AuthenticationError
-          retry unless (tries -= 1).zero?
+          if (tries -= 1).zero?
+            raise Docker::Error::AuthenticationError, "#{new_resource.username} failed to authenticate with #{new_resource.serveraddress}"
+          else
+            retry
+          end
         end
       end
     end

--- a/libraries/provider_docker_service_systemd.rb
+++ b/libraries/provider_docker_service_systemd.rb
@@ -45,7 +45,7 @@ class Chef
           end
 
           # tmpfiles.d config so the service survives reboot
-          template '/usr//lib/tmpfiles.d/docker.conf' do
+          template '/usr/lib/tmpfiles.d/docker.conf' do
             path '/usr/lib/tmpfiles.d/docker.conf'
             source "#{docker_major_version}/systemd/tmpfiles.d.conf.erb"
             owner 'root'

--- a/spec/docker_service_test/sysvinit_spec.rb
+++ b/spec/docker_service_test/sysvinit_spec.rb
@@ -4,8 +4,7 @@ describe 'Chef::Provider::DockerService::Sysvinit with Centos' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
       platform: 'centos',
-      version: '7.0',
-      step_into: 'docker_service'
+      version: '7.0'
     ).converge('docker_service_test::sysvinit')
   end
 

--- a/spec/docker_service_test/sysvinit_spec.rb
+++ b/spec/docker_service_test/sysvinit_spec.rb
@@ -14,6 +14,6 @@ describe 'Chef::Provider::DockerService::Sysvinit with Centos' do
   end
 
   it 'creates the sysvinit file' do
-    expect(chef_run).to render_file('/etc/init.d/docker')
+    expect(chef_run).to create_template('/etc/init.d/docker')
   end
 end

--- a/spec/docker_service_test/sysvinit_spec.rb
+++ b/spec/docker_service_test/sysvinit_spec.rb
@@ -4,7 +4,8 @@ describe 'Chef::Provider::DockerService::Sysvinit with Centos' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
       platform: 'centos',
-      version: '7.0'
+      version: '7.0',
+      step_into: 'docker_service'
     ).converge('docker_service_test::sysvinit')
   end
 


### PR DESCRIPTION
The rescue block allowed multiple login attempts, but the exception was not resurfaced when the retry limit was reached.