### PR TITLE
Update docker_service_test/socket_spec.rb to docker 1.8.2

### DIFF
--- a/spec/docker_service_test/socket_spec.rb
+++ b/spec/docker_service_test/socket_spec.rb
@@ -22,8 +22,8 @@ describe 'docker_service_test::socket on centos-7.0' do
     it 'creates remote_file[/usr/bin/docker]' do
       expect(default).to create_remote_file('/usr/bin/docker')
         .with(
-          source: 'http://get.docker.io/builds/Linux/x86_64/docker-1.8.1',
-          checksum: '843f90f5001e87d639df82441342e6d4c53886c65f72a5cc4765a7ba3ad4fc57',
+          source: 'http://get.docker.io/builds/Linux/x86_64/docker-1.8.2',
+          checksum: '97a3f5924b0b831a310efa8bf0a4c91956cd6387c4a8667d27e2b2dd3da67e4d',
           owner: 'root',
           group: 'root',
           mode: '0755'


### PR DESCRIPTION
Fixes test regression from [`711a6faf`](https://github.com/bflad/chef-docker/commit/711a6fafb74037cab955069383f2c7d4927a156c#diff-51c36c8f820c0f1bf918f59163c3d498R83)