### PR TITLE
Remove nonexistent action :enable from docker_service

### DIFF
--- a/libraries/provider_docker_service.rb
+++ b/libraries/provider_docker_service.rb
@@ -50,9 +50,6 @@ class Chef
 
       action :restart do
       end
-
-      action :enable do
-      end
     end
   end
 end


### PR DESCRIPTION
I noticed the [docker_service](https://github.com/bflad/chef-docker/blob/master/libraries/resource_docker_service.rb#L10) resource doesn't actually specify `:enable` action, so this just cleans that up.

Note: this depends on #425 to be merged in for the tests to pass.