### PR TITLE
Use get.docker.com instead of get.docker.io

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -89,11 +89,11 @@ module DockerHelpers
     ray.push.join('.')
   end
 
-  # https://get.docker.io/builds/Linux/x86_64/docker-1.8.2
-  # https://get.docker.io/builds/Darwin/x86_64/docker-1.8.2
+  # https://get.docker.com/builds/Linux/x86_64/docker-1.8.2
+  # https://get.docker.com/builds/Darwin/x86_64/docker-1.8.2
   def parsed_source
     return new_resource.source if new_resource.source
-    "https://get.docker.io/builds/#{docker_kernel}/#{docker_arch}/docker-#{parsed_version}"
+    "https://get.docker.com/builds/#{docker_kernel}/#{docker_arch}/docker-#{parsed_version}"
   end
 
   def docker_daemon_cmd

--- a/spec/docker_service_test/socket_spec.rb
+++ b/spec/docker_service_test/socket_spec.rb
@@ -22,7 +22,7 @@ describe 'docker_service_test::socket on centos-7.0' do
     it 'creates remote_file[/usr/bin/docker]' do
       expect(default).to create_remote_file('/usr/bin/docker')
         .with(
-          source: 'https://get.docker.io/builds/Linux/x86_64/docker-1.8.2',
+          source: 'https://get.docker.com/builds/Linux/x86_64/docker-1.8.2',
           checksum: '97a3f5924b0b831a310efa8bf0a4c91956cd6387c4a8667d27e2b2dd3da67e4d',
           owner: 'root',
           group: 'root',


### PR DESCRIPTION
While attempting to revive the [`docker_service` kitchen test suite](https://github.com/bflad/chef-docker/blob/master/.kitchen.yml#L63-L73), I noticed that Chef wasn't able to actually fetch the docker binary from the `get.docker.io` URL:

```sh-session
       Recipe: docker_service_test::socket
         * docker_service[default] action createRecipe: <Dynamically Defined Resource>
         * remote_file[/usr/bin/docker] action create[2015-09-16T14:36:09+00:00] WARN: remote_file[/usr/bin/docker] cannot be downloaded from https://get.docker.io/builds/Linux/x86_64/docker-1.6.2: 503 "Service Unavailable"

       ================================================================================
       Error executing action `create` on resource 'remote_file[/usr/bin/docker]'
       ================================================================================

       Net::HTTPFatalError
       -------------------
       503 "Service Unavailable"

       Resource Declaration:
       ---------------------
       # In /tmp/kitchen/cache/cookbooks/docker/libraries/docker_service.rb
```

While investigating, I noticed that `get.docker.io` simply redirects to `get.docker.com`:

```sh-session
vagrant@service-socket-ubuntu-1404:~$ wget https://get.docker.io/builds/Linux/x86_64/docker-1.6.2 > dockers
--2015-09-16 14:36:56--  https://get.docker.io/builds/Linux/x86_64/docker-1.6.2
Resolving get.docker.io (get.docker.io)... 54.88.210.164, 54.88.164.232, 54.174.187.194
Connecting to get.docker.io (get.docker.io)|54.88.210.164|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://get.docker.com/builds/Linux/x86_64/docker-1.6.2 [following]
--2015-09-16 14:36:56--  https://get.docker.com/builds/Linux/x86_64/docker-1.6.2
Resolving get.docker.com (get.docker.com)... 54.192.48.94, 54.192.48.103, 54.192.48.113, ...
Connecting to get.docker.com (get.docker.com)|54.192.48.94|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 15443675 (15M) [binary/octet-stream]
Saving to: ‘docker-1.6.2’
```

It also seems this is the URL [Docker's documentation advocates for](https://docs.docker.com/installation/binaries/#get-the-linux-binary), so I decided to go ahead and update the code to use `get.docker.com` instead of `get.docker.io`.

After this change, fetching the binary is successful:
```sh-session
       Recipe: docker_service_test::socket
         * docker_service[default] action createRecipe: <Dynamically Defined Resource>
         * remote_file[/usr/bin/docker] action create
           - create new file /usr/bin/docker
           - update content in file /usr/bin/docker from none to e131b2
        (file sizes exceed 10000000 bytes, diff output suppressed)
           - change mode from '' to '0755'
           - change owner from '' to 'root'
           - change group from '' to 'root'
```