### PR TITLE
Support more logging drivers and allow specifying logging driver options

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ the options found in the
 - `ipv6` - Enable IPv6 networking
 - `log_level` - Set the logging level
 - `label` - Set key=value labels to the daemon
-- `log_driver` - Container's logging driver (json-file/none)
+- `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/none)
+- `log_opts` - Container's logging driver options (driver-specific)
 - `mtu` - Container's logging driver (json-file/none)
 - `pidfile` - Path to use for daemon PID file
 - `registry_mirror` - Preferred Docker registry mirror

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -123,6 +123,10 @@ module DockerHelpers
     r
   end
 
+  def parsed_log_opts
+    Array(new_resource.log_opts)
+  end
+
   def parsed_storage_driver
     Array(new_resource.storage_driver)
   end
@@ -156,6 +160,7 @@ module DockerHelpers
     opts << "--log-level=#{new_resource.log_level}" if new_resource.log_level
     opts << "--label=#{new_resource.label}" if new_resource.label
     opts << "--log-driver=#{new_resource.log_driver}" if new_resource.log_driver
+    parsed_log_opts.each { |log_opt| opts << "--log-opt=#{log_opt}" }
     opts << "--mtu=#{new_resource.mtu}" if new_resource.mtu
     opts << "--pidfile=#{new_resource.pidfile}" if new_resource.pidfile
     opts << "--registry-mirror=#{new_resource.registry_mirror}" if new_resource.registry_mirror

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -44,7 +44,8 @@ class Chef
       attribute :ipv6, kind_of: [TrueClass, FalseClass], default: nil
       attribute :log_level, equal_to: [:debug, :info, :warn, :error, :fatal], default: nil
       attribute :label, kind_of: String, default: nil
-      attribute :log_driver, equal_to: %w( json-file syslog none ), default: nil
+      attribute :log_driver, equal_to: %w( json-file syslog journald gelf fluentd none ), default: nil
+      attribute :log_opts, kind_of: [String, Array], default: []
       attribute :mtu, kind_of: String, default: nil
       attribute :pidfile, kind_of: String, default: nil
       attribute :registry_mirror, kind_of: String, default: nil


### PR DESCRIPTION
A simple PR to update the whitelist of logging drivers supported by the docker service. It also adds a new `log_opts' attribute to the docker_service, which allows to configure the exotic logging drivers such as fluentd or syslog.

The list of supported logging drivers can be found at the top of this page: https://docs.docker.com/reference/logging/overview/