### PR TITLE
Allow specifying multiple dns servers to docker_service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ the options found in the
 - `bip` - Specify network bridge IP
 - `debug` - Enable debug mode
 - `daemon` - Enable daemon mode
-- `dns` - DNS server to use
+- `dns` - DNS server(s) to use
 - `dns_search` - DNS search domains to use
 - `exec_driver` - Exec driver to use
 - `fixed_cidr` - IPv4 subnet for fixed IPs

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -108,6 +108,10 @@ module DockerHelpers
     [docker_bin, docker_daemon_arg, docker_opts].join(' ')
   end
 
+  def parsed_dns
+    Array(new_resource.dns)
+  end
+
   # strip out invalid host arguments
   def parsed_host
     sockets = new_resource.host.split if new_resource.host.is_a?(String)
@@ -138,7 +142,7 @@ module DockerHelpers
     opts << "--bip=#{new_resource.bip}" if new_resource.bip
     opts << '--debug' if new_resource.debug
     opts << "--default-ulimit=#{new_resource.default_ulimit}" if new_resource.default_ulimit
-    opts << "--dns=#{new_resource.dns}" if new_resource.dns
+    parsed_dns.each { |dns| opts << "--dns=#{dns}" }
     new_resource.dns_search.each { |dns| opts << "--dns-search=#{dns}" } if new_resource.dns_search
     opts << "--exec-driver=#{new_resource.exec_driver}" if new_resource.exec_driver
     opts << "--fixed-cidr=#{new_resource.fixed_cidr}" if new_resource.fixed_cidr

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -25,7 +25,7 @@ class Chef
       attribute :bip, kind_of: String, regex: [IPV4_ADDR, IPV4_CIDR, IPV6_ADDR, IPV6_CIDR],  default: nil
       attribute :debug, kind_of: [TrueClass, FalseClass], default: nil
       attribute :daemon, kind_of: [TrueClass, FalseClass], default: true
-      attribute :dns, kind_of: String, default: nil
+      attribute :dns, kind_of: [String, Array], default: []
       attribute :dns_search, kind_of: Array, default: nil
       attribute :exec_driver, equal_to: %w(native lxc), default: nil
       attribute :fixed_cidr, kind_of: String, default: nil


### PR DESCRIPTION
Per [documentation](http://docs.docker.com/reference/commandline/daemon/), the docker daemon accepts multiple --dns options.

This PR allows the `docker_service` dns attribute to be either a String (like today) or an Array of string.