### PR TITLE
Prevents `rake -T` from blowing when no kitchen-vagrant driver installed.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ namespace :integration do
 
     desc 'Run kitchen integration tests'
     Kitchen::RakeTasks.new
-  rescue LoadError
+  rescue LoadError, Kitchen::ClientError
     puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
   end
 end


### PR DESCRIPTION
After running `bundle install` on a fresh copy of this repository, running `bundle exec rake -T` (or any other rake command) would fail with Kitchen::ClientError when no kitchen-vagrant driver is installed.

I just wanted to run the rubocop task so I made this PR.