### PR TITLE
Redeploy unstarted containers using action_create instead of action_run.

### DIFF
--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -305,8 +305,14 @@ class Chef
       end
 
       action :redeploy do
+        c = Docker::Container.get(new_resource.container_name)
+        previously_running = c.info['State']['Running']
         action_delete
-        action_run
+        if previously_running
+          action_run
+        else
+          action_create
+        end
       end
 
       action :delete do

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -195,10 +195,19 @@ docker_container 'redeployer' do
   action :run
 end
 
-execute 'redeploy redeployer' do
+docker_container 'unstarted_redeployer' do
+  repo 'alpine'
+  tag '3.1'
+  command 'nc -ll -p 7777 -e /bin/cat'
+  port '7'
+  action :create
+end
+
+execute 'redeploy redeployers' do
   command 'touch /marker_container_redeployer'
   creates '/marker_container_redeployer'
   notifies :redeploy, 'docker_container[redeployer]', :immediately
+  notifies :redeploy, 'docker_container[unstarted_redeployer]', :immediately
   action :run
 end
 

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -227,6 +227,14 @@ describe command("docker ps -af 'name=redeployer$'") do
   its(:stdout) { should_not match(/Exited/) }
 end
 
+# docker_container[unstarted_redeployer]
+
+describe command("docker ps -af 'name=unstarted_redeployer$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/Up/) }
+  its(:stdout) { should match(/Created/) } if docker_version.to_f >= 1.8
+end
+
 # docker_container[bind_mounter]
 
 describe command("docker ps -af 'name=bind_mounter$'") do

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -227,6 +227,14 @@ describe command("docker ps -af 'name=redeployer$'") do
   its(:stdout) { should_not match(/Exited/) }
 end
 
+# docker_container[unstarted_redeployer]
+
+describe command("docker ps -af 'name=unstarted_redeployer$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/Up/) }
+  its(:stdout) { should match(/Created/) } if docker_version.to_f >= 1.8
+end
+
 # docker_container[bind_mounter]
 
 describe command("docker ps -af 'name=bind_mounter$'") do

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -227,6 +227,14 @@ describe command("docker ps -af 'name=redeployer$'") do
   its(:stdout) { should_not match(/Exited/) }
 end
 
+# docker_container[unstarted_redeployer]
+
+describe command("docker ps -af 'name=unstarted_redeployer$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/Up/) }
+  its(:stdout) { should match(/Created/) } if docker_version.to_f >= 1.8
+end
+
 # docker_container[bind_mounter]
 
 describe command("docker ps -af 'name=bind_mounter$'") do


### PR DESCRIPTION
This PR is my attempt at fixing #432.

For some reason, I was not able to run the serverspec ("kitchen setup" then "kitchen verify" are no-ops), so I ran my rspec examples manually on both resources-ubuntu-1404 and resources-ubuntu1504 instances after converging them.

My server spec example:
```ruby
# docker_container[unstarted_redeployer]

describe command("docker ps -af 'name=unstarted_redeployer$'") do
  its(:exit_status) { should eq 0 }
  its(:stdout) { should_not match(/Up/) }
  its(:stdout) { should match(/Created/) } if docker_version.to_f >= 1.8
end
```

The results (note the different container status pre and post docker 1.8).

On 14.04 (docker 1.6.2):
```sh
root@resources-ubuntu-1404:~# docker ps -a | grep redeployer
d8a8e41dc7e0        alpine:3.1               "nc -ll -p 7777 -e /   About a minute ago                                                                 unstarted_redeployer      
151eb96b1e3f        alpine:3.1               "nc -ll -p 7777 -e /   About a minute ago   Up About a minute             0.0.0.0:32777->7/tcp            redeployer                
```

On ubuntu 15.04 (docker 1.8.2):
```sh
root@vagrant:~# docker ps -a | grep redeployer
14fbef4889dc        alpine:3.1               "nc -ll -p 7777 -e /b"   5 seconds ago       Created                                                       unstarted_redeployer
dec1e2c6285d        alpine:3.1               "nc -ll -p 7777 -e /b"   5 seconds ago       Up 4 seconds                  0.0.0.0:32777->7/tcp            redeployer
```