### PR TITLE
Qualify port bindings with protocol even when implicitly tcp

### DIFF
--- a/libraries/_port_binding.rb
+++ b/libraries/_port_binding.rb
@@ -44,5 +44,7 @@ class PortBinding
     when 1
       @container_port = parts[0]
     end
+    # qualify the port-binding protocol even when it is implicitly tcp #427.
+    @container_port << '/tcp' unless @container_port.include?('/')
   end
 end

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -141,16 +141,31 @@ describe command("[ ! -z `docker ps -qaf 'name=an_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
 end
 
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/tcp') }
+end
+
 # docker_container[another_echo_server]
 
 describe command("[ ! -z `docker ps -qaf 'name=another_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
 end
 
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' another_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/tcp') }
+end
+
 # docker_container[an_udp_echo_server]
 
 describe command("[ ! -z `docker ps -qaf 'name=an_udp_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
+end
+
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_udp_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/udp') }
 end
 
 # docker_container[bill]

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -141,16 +141,31 @@ describe command("[ ! -z `docker ps -qaf 'name=an_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
 end
 
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/tcp') }
+end
+
 # docker_container[another_echo_server]
 
 describe command("[ ! -z `docker ps -qaf 'name=another_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
 end
 
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' another_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/tcp') }
+end
+
 # docker_container[an_udp_echo_server]
 
 describe command("[ ! -z `docker ps -qaf 'name=an_udp_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
+end
+
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_udp_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/udp') }
 end
 
 # docker_container[bill]

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -141,16 +141,31 @@ describe command("[ ! -z `docker ps -qaf 'name=an_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
 end
 
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/tcp') }
+end
+
 # docker_container[another_echo_server]
 
 describe command("[ ! -z `docker ps -qaf 'name=another_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
 end
 
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' another_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/tcp') }
+end
+
 # docker_container[an_udp_echo_server]
 
 describe command("[ ! -z `docker ps -qaf 'name=an_udp_echo_server$'` ]") do
   its(:exit_status) { should eq 0 }
+end
+
+describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_udp_echo_server") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should eq('7/udp') }
 end
 
 # docker_container[bill]


### PR DESCRIPTION
Fixes #427.

Validated by running `kitchen test resources-182-ubuntu-1404` (no time/bandwidth to run on all supported combinations).