### PR TITLE
Fixed serverspec after #439 and #437 merges.

### DIFF
--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -306,12 +306,13 @@ class Chef
 
       action :redeploy do
         c = Docker::Container.get(new_resource.container_name)
-        previously_running = c.info['State']['Running']
         action_delete
-        if previously_running
-          action_run
-        else
+        # never start containers resulting from a previous action :create #432
+        if c.info['State']['Running'] == false &&
+           c.info['State']['StartedAt'] == '0001-01-01T00:00:00Z'
           action_create
+        else
+          action_run
         end
       end
 

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -143,7 +143,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/tcp') }
+  its(:stdout) { should include('7/tcp') }
 end
 
 # docker_container[another_echo_server]
@@ -154,7 +154,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' another_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/tcp') }
+  its(:stdout) { should include('7/tcp') }
 end
 
 # docker_container[an_udp_echo_server]
@@ -165,7 +165,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_udp_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/udp') }
+  its(:stdout) { should include('7/udp') }
 end
 
 # docker_container[bill]

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -143,7 +143,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/tcp') }
+  its(:stdout) { should include('7/tcp') }
 end
 
 # docker_container[another_echo_server]
@@ -154,7 +154,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' another_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/tcp') }
+  its(:stdout) { should include('7/tcp') }
 end
 
 # docker_container[an_udp_echo_server]
@@ -165,7 +165,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_udp_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/udp') }
+  its(:stdout) { should include('7/udp') }
 end
 
 # docker_container[bill]

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -143,7 +143,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/tcp') }
+  its(:stdout) { should include('7/tcp') }
 end
 
 # docker_container[another_echo_server]
@@ -154,7 +154,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' another_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/tcp') }
+  its(:stdout) { should include('7/tcp') }
 end
 
 # docker_container[an_udp_echo_server]
@@ -165,7 +165,7 @@ end
 
 describe command("docker inspect --format '{{ range $port, $_ := .HostConfig.PortBindings }}{{ $port }}{{ end }}' an_udp_echo_server") do
   its(:exit_status) { should eq 0 }
-  its(:stdout) { should eq('7/udp') }
+  its(:stdout) { should include('7/udp') }
 end
 
 # docker_container[bill]


### PR DESCRIPTION
This PR fixes recent breakage in serverspec introduced by some of my recent PRs. Breakage log from @someara here: https://gist.github.com/someara/2066171ebcb5f3a95da5#file-gistfile1-txt-L590

First breakage was due using too strict matcher when parsing the docker inspect output in #439 
Second breakage was more serious and due to false positive when matching for 'unstarted containers' in #437