### PR TITLE
Added docker_container log_driver and log_opts attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,18 @@ docker_container 'api_timeouts' do
 end
 ```
 
+Specify a custom logging driver and its options
+
+```ruby
+docker_container 'syslogger' do
+  repo 'alpine'
+  tag '3.1'
+  command 'nc -ll -p 780 -e /bin/cat'
+  log_driver 'syslog'
+  log_opts 'syslog-tag=container-syslogger'
+end
+```
+
 #### Properties
 
 Most `docker_container` properties are the `snake_case` version of the
@@ -853,6 +865,9 @@ Most `docker_container` properties are the `snake_case` version of the
 - `host_name` - The hostname for the container.
 - `links` - An array of source container/alias pairs to link the
   container to in the form `[container_a:www', container_b:db']`
+- `log_driver` - Sets a custom logging driver for the container
+  (json-file/syslog/journald/gelf/fluentd/none).
+- `log_opts` - Configures the above logging driver options (driver-specific).
 - `mac_address` - The mac address for the container to use.
 - `memory` - Memory limit in bytes.
 - `memory_swap` - Total memory limit (memory + swap); set `-1` to

--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -142,7 +142,7 @@ class Chef
             'DnsSearch' => parsed_dns_search,
             'ExtraHosts' => parsed_extra_hosts,
             'Links' => parsed_links,
-            'LogConfig' => new_resource.log_config,
+            'LogConfig' => serialized_log_config,
             'Memory' => new_resource.memory,
             'MemorySwap' => new_resource.memory_swap,
             'NetworkMode' => parsed_network_mode,

--- a/libraries/resource_docker_container.rb
+++ b/libraries/resource_docker_container.rb
@@ -34,7 +34,9 @@ class Chef
       attribute :force, kind_of: [TrueClass, FalseClass], default: false
       attribute :host_name, kind_of: String, default: nil
       attribute :links, kind_of: [String, Array, NilClass], default: nil # FIXME: add validate proc
-      attribute :log_config, kind_of: [Hash, NilClass], default: nil # FIXME: add validate proc and tests
+      attribute :log_config, kind_of: [Hash, NilClass], default: nil # FIXME: add validate proc and tests; to configure the resource, prefer log_driver/log_opts below
+      attribute :log_driver, equal_to: %w( json-file syslog journald gelf fluentd none ), default: nil
+      attribute :log_opts, kind_of: [String, Array], default: []
       attribute :mac_address, kind_of: String, default: '' # FIXME: needs tests
       attribute :memory, kind_of: Fixnum, default: 0
       attribute :memory_swap, kind_of: Fixnum, default: 0

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -868,3 +868,15 @@ docker_container 'overrides-2' do
   workdir '/tmp'
   action :run_if_missing
 end
+
+#################
+# logging drivers
+#################
+
+docker_container 'syslogger' do
+  command 'nc -ll -p 780 -e /bin/cat'
+  repo 'alpine'
+  tag '3.1'
+  log_driver 'syslog'
+  log_opts 'syslog-tag=container-syslogger'
+end

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -643,3 +643,20 @@ describe command('docker inspect -f "{{ .Config.WorkingDir }}" overrides-2') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(%r{/tmp}) }
 end
+
+# docker_container[syslogger]
+
+describe command("docker ps -af 'name=syslogger$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/Exited/) }
+end
+
+describe command("docker inspect -f '{{ .HostConfig.LogConfig.Type }}' syslogger") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/syslog/) }
+end
+
+describe command("docker inspect -f '{{ .HostConfig.LogConfig.Config }}' syslogger") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/syslog-tag:container-syslogger/) }
+end

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -643,3 +643,20 @@ describe command('docker inspect -f "{{ .Config.WorkingDir }}" overrides-2') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(%r{/tmp}) }
 end
+
+# docker_container[syslogger]
+
+describe command("docker ps -af 'name=syslogger$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/Exited/) }
+end
+
+describe command("docker inspect -f '{{ .HostConfig.LogConfig.Type }}' syslogger") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/syslog/) }
+end
+
+describe command("docker inspect -f '{{ .HostConfig.LogConfig.Config }}' syslogger") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/syslog-tag:container-syslogger/) }
+end

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -643,3 +643,20 @@ describe command('docker inspect -f "{{ .Config.WorkingDir }}" overrides-2') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(%r{/tmp}) }
 end
+
+# docker_container[syslogger]
+
+describe command("docker ps -af 'name=syslogger$'") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should_not match(/Exited/) }
+end
+
+describe command("docker inspect -f '{{ .HostConfig.LogConfig.Type }}' syslogger") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/syslog/) }
+end
+
+describe command("docker inspect -f '{{ .HostConfig.LogConfig.Config }}' syslogger") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/syslog-tag:container-syslogger/) }
+end


### PR DESCRIPTION
This PR allows to configure logging on a per-container basis, when the logging driver or its configuration is different than the systemwide (docker_service) defaults.

It introduces two new attributes for docker_container:
 - log_driver = %w( json-file syslog journald gelf fluentd none )
 - log_opts = Array of "key=value" strings that are specific to each log-driver
Which work similarly to the eponymous attributes of the `docker_service` resource.

Use the new attribute like this:
```ruby
docker_container 'syslogger' do
  command 'nc -ll -p 780 -e /bin/cat'
  repo 'alpine'
  tag '3.1'
  log_driver 'syslog'
  log_opts 'syslog-tag=container-syslogger'
end
```

The stubbed handling of docker_container log_config attribute has been fixed and updated to handle the 2 new attributes, which are an higher-level way to configure container logging.

I have tested compatibility with the `resources-162-ubuntu-1404`, `resources-171-ubuntu-1404` and `resources-182-ubuntu-1404` suites, so I think that it is compatible with all versions of docker that this cookbook supports.