### PR TITLE
Fix unwanted redeploys due to calculation of exposed_port changes.

### DIFF
--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -260,5 +260,11 @@ module DockerHelpers
       return true if (!new_resource.hostname.nil?) && (current_resource.hostname != new_resource.hostname)
       false
     end
+
+    def update_exposed_ports?
+      return false if new_resource.exposed_ports.nil?
+      return true if current_resource.exposed_ports != new_resource.exposed_ports
+      false
+    end
   end
 end

--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -80,7 +80,7 @@ class Chef
         changes << :domainname if current_resource.domainname != new_resource.domainname
         changes << :entrypoint if update_entrypoint?
         changes << :env if update_env?
-        changes << :exposed_ports if current_resource.exposed_ports != exposed_ports
+        changes << :exposed_ports if update_exposed_ports?
         changes << :extra_hosts if current_resource.extra_hosts != parsed_extra_hosts
         changes << :hostname if update_hostname?
         changes << :image if current_resource.image != "#{parsed_repo}:#{new_resource.tag}"
@@ -173,6 +173,7 @@ class Chef
         Chef::Log.debug("DOCKER: command - current:#{current_resource.command}: parsed:#{parsed_command}:")
         Chef::Log.debug("DOCKER: entrypoint - current:#{current_resource.entrypoint}: parsed:#{parsed_entrypoint}:")
         Chef::Log.debug("DOCKER: env - current:#{current_resource.env}: parsed:#{parsed_env}:")
+        Chef::Log.debug("DOCKER: exposed_ports - current:#{current_resource.exposed_ports}: serialized:#{exposed_ports}:")
         Chef::Log.debug("DOCKER: volumes - current:#{current_resource.volumes}: parsed:#{parsed_volumes}:")
         Chef::Log.debug("DOCKER: network_mode - current:#{current_resource.network_mode}: parsed:#{parsed_network_mode}:")
         Chef::Log.debug("DOCKER: log_config - current:#{current_resource.log_config}: serialized:#{serialized_log_config}:")


### PR DESCRIPTION
The handling of exposed_ports is tricky because some exposed_ports are injected from the image (EXPOSE instruction in Dockerfile). As such, we cannot rely on new_resource.exposed_ports and new_resource.port to declare which ports are actually be exposed.

The consequence is #446 where a container with multiple ports exposed from Dockerfile and at least one which is not bound (new_resource.port) is redeployed at every chef-run.

This PR fixes #446