### PR TITLE
Treat docker_container volumes attribute as unmanaged to prevent redeploys.

### DIFF
--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -239,6 +239,7 @@ module DockerHelpers
 
     def update_volumes?
       return false if parsed_volumes.nil?
+      return true if current_resource.volumes.nil?
       return true unless parsed_volumes.each { |v| current_resource.volumes.include?(v) }
       false
     end

--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -100,7 +100,7 @@ class Chef
         changes << :tty if current_resource.tty != new_resource.tty
         changes << :ulimits if update_ulimits?
         changes << :user if current_resource.user != new_resource.user
-        changes << :volumes if current_resource.volumes != parsed_volumes
+        changes << :volumes if update_volumes?
         changes << :volumes_from if current_resource.volumes_from != parsed_volumes_from
         changes << :working_dir if update_working_dir?
         changes


### PR DESCRIPTION
This PR should fix #449.

The existing code already had a "update_volumes?" method, it was just not being used to compute the list of "resource_changes" in the docker container. I also handled a case where current_resource.volumes is nil (this happens in the test suite with the 'chef_container', where parsed_volumes is {"/opt/chef" => {}} while current_resource.volumes is nil; then obviously the container should be redeployed).