### PR TITLE
Changed default docker_container memory_swap to prevent unwanted redeploys.

### DIFF
--- a/libraries/resource_docker_container.rb
+++ b/libraries/resource_docker_container.rb
@@ -39,7 +39,7 @@ class Chef
       attribute :log_opts, kind_of: [String, Array], default: []
       attribute :mac_address, kind_of: String, default: '' # FIXME: needs tests
       attribute :memory, kind_of: Fixnum, default: 0
-      attribute :memory_swap, kind_of: Fixnum, default: 0
+      attribute :memory_swap, kind_of: Fixnum, default: -1
       attribute :network_disabled, kind_of: [TrueClass, FalseClass], default: false
       attribute :network_mode, kind_of: [String, NilClass], default: nil
       attribute :open_stdin, kind_of: [TrueClass, FalseClass], default: false


### PR DESCRIPTION
This PR sets the default value for `docker_container.memory_swap` to `-1` (unlimited) from the current value of `0` (which also means unlimited if I believe the [docker code](https://github.com/docker/docker/blob/dac92a8afbe0900641afa00e33e84e180d432239/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/memory.go#L62)).

# Why

On some systems, I have noticed that setting that value to 0 in the cookbook results in a value of -1 being displayed in the output of `docker inspect -f '{{ .HostConfig.MemorySwap }}`.

This happens when:
 - a positive value is provided for `docker_container.memory` (eg. `'128m'`)
 - the system is running under some kernel versions (see below)

The consequence is that on affected systems, containers which specify a positive value for `docker_container.memory` will get redeployed at every chef-run.

# How to reproduce

On all systems, when both memory and memory-swap are set to 0 the correct values are always listed in `docker inspect` output.

On all systems I am using docker 1.8.2 (current stable version as of late September 2015).

```sh
root@resources-182-ubuntu-1404:~# docker run -d --name xxx --memory=0 --memory-swap=0 busybox:ubuntu-14.04 nc -lp 777
root@resources-182-ubuntu-1404:~# docker inspect -f 'memory: {{ .HostConfig.Memory }}, memory_swap: {{.HostConfig.MemorySwap }}'  xxx
memory: 0, memory_swap: 0 # <-- correct behavior, memory and memory_swap values are those specified in the docker-run cmdline above
```

## Kitchen VM

The `resources-182-ubuntu-1404` VM from this cookbook's test kitchen displays the bug.

```sh
root@resources-182-ubuntu-1404:~# uname -a
Linux resources-182-ubuntu-1404 3.19.0-25-generic #26~14.04.1-Ubuntu SMP Fri Jul 24 21:16:20 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
root@resources-182-ubuntu-1404:~# docker run -d --name xxx --memory=128m --memory-swap=0 busybox:ubuntu-14.04 nc -lp 777
root@resources-182-ubuntu-1404:~# docker inspect -f 'memory: {{ .HostConfig.Memory }}, memory_swap: {{.HostConfig.MemorySwap }}'  xxx
memory: 134217728, memory_swap: -1 # bug, memory_swap is -1, which is different than the 0 we initially specified
```

## A production system reproducing the bug

```sh
root@prod2-compute2:~# uname -a
Linux prod2-compute2 3.13.0-49-generic #83-Ubuntu SMP Fri Apr 10 20:11:33 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
root@prod2-compute2:~# docker run -d --name xxx --memory=128m --memory-swap=0 busybox:ubuntu-14.04 nc -lp 777
root@prod2-compute2:~# docker inspect -f 'memory: {{ .HostConfig.Memory }}, memory_swap: {{.HostConfig.MemorySwap }}'  xxx
memory: 134217728, memory_swap: -1 # <--- bug
```

## Another production system, this time NOT reproducing the bug

```sh
root@compute:~# uname -a
Linux compute 3.14.32-xxxx-grs-ipv6-64 #1 SMP Tue Jun 30 18:50:21 CEST 2015 x86_64 x86_64 x86_64 GNU/Linux
root@compute:~# docker run -d --name xxx --memory=128m --memory-swap=0 busybox:ubuntu-14.04 nc -lp 777
root@compute:~#  docker inspect -f 'memory: {{ .HostConfig.Memory }}, memory_swap: {{.HostConfig.MemorySwap }}'  xxx
memory: 134217728, memory_swap: 0 # <--- appears to work
```

# The fix

Setting `docker_container.memory_swap` to `-1` by default works in all cases, when memory is set to 0 (default for the docker_container resource) and when memory is set to a positive value.

```sh
root@resources-182-ubuntu-1404:~# docker run -d --name xxx --memory=128m --memory-swap=-1 busybox:ubuntu-14.04 nc -lp 777
root@resources-182-ubuntu-1404:~# docker inspect -f 'memory: {{ .HostConfig.Memory }}, memory_swap: {{.HostConfig.MemorySwap }}'  xxx
memory: 134217728, memory_swap: -1 # <--- correct
root@resources-182-ubuntu-1404:~# docker run -d --name xxx --memory=0 --memory-swap=-1 busybox:ubuntu-14.04 nc -lp 777
root@resources-182-ubuntu-1404:~# docker inspect -f 'memory: {{ .HostConfig.Memory }}, memory_swap: {{.HostConfig.MemorySwap }}'  xxx
memory: 0, memory_swap: -1 # <---- correct
```