### PR TITLE
Fix registry auth and slightly refactor `docker pull`

### DIFF
--- a/libraries/helpers_auth.rb
+++ b/libraries/helpers_auth.rb
@@ -1,0 +1,6 @@
+module DockerHelpers
+  # https://github.com/docker/docker/blob/4fcb9ac40ce33c4d6e08d5669af6be5e076e2574/registry/auth.go#L231
+  def parse_registry_host(val)
+    val.sub(%r{https?://}, '').split('/').first
+  end
+end

--- a/libraries/provider_docker_registry.rb
+++ b/libraries/provider_docker_registry.rb
@@ -7,21 +7,30 @@ class Chef
       provides :docker_registry if Chef::Provider.respond_to?(:provides)
 
       action :login do
+        tries = new_resource.api_retries
+
+        # https://github.com/docker/docker/blob/4fcb9ac40ce33c4d6e08d5669af6be5e076e2574/registry/auth.go#L231
+        registry_host = new_resource.serveraddress.sub(%r{https?://}, '').split('/').first
+
+        (node.run_state[:docker_auth] ||= {})[registry_host] = {
+          'serveraddress' => registry_host,
+          'username' => new_resource.username,
+          'password' => new_resource.password,
+          'email' => new_resource.email
+        }
+
         begin
-          tries ||= new_resource.api_retries
-          Docker.authenticate!(
-            'serveraddress' => new_resource.serveraddress,
-            'username' => new_resource.username,
-            'password' => new_resource.password,
-            'email' => new_resource.email
-          )
-        rescue Docker::Error::AuthenticationError
+          Docker.connection.post('/auth', {},
+                                 body: node.run_state[:docker_auth][registry_host].to_json)
+        rescue Docker::Error::ServerError, Docker::Error::UnauthorizedError
           if (tries -= 1).zero?
             raise Docker::Error::AuthenticationError, "#{new_resource.username} failed to authenticate with #{new_resource.serveraddress}"
           else
             retry
           end
         end
+
+        true
       end
     end
   end


### PR DESCRIPTION
This fixes registry authentication (hopefully for good), which is still broken in 1.0.32.

When you use `Docker.authenticate!`, it sets the credentials for *all* registry API calls. This means that we can't set credentials for multiple registries upfront -- each one you set simply overrides the last. It also creates problems like we saw in #417 when credentials for a private registry are used during a call to what's supposed to be a public registry.

Instead of using `Docker.authenticate!`, we instead parse `docker_registry`'s `serveraddress` as the real `docker pull` command does and store the credentials in the node's `run_state`. We then manually verify credentials using `Docker.connection`.

We also need to refactor `docker pull` emulation:

https://github.com/BWITS/docker-api/blob/9d4ba7df1a6b52bf4d4ff1ee04c160b06939717f/README.md

According to the above link, the proper way to emulate a `docker pull` is to use `Docker::Image.create`. This call accepts a Hash containing credentials for the image creation as the second argument. It also rids of all the workarounds in place that attempted to solve #417.