### PR TITLE
updates to foodcritic for rake and travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   - /opt/chefdk/embedded/bin/rubocop --version
   - /opt/chefdk/embedded/bin/rubocop
   - /opt/chefdk/embedded/bin/foodcritic --version
-  - /opt/chefdk/embedded/bin/foodcritic --tags ~FC009 . --exclude spec
+  - /opt/chefdk/embedded/bin/foodcritic -f any . --exclude spec
   - /opt/chefdk/embedded/bin/rspec spec

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,8 @@ namespace :style do
     desc 'Run Chef style checks'
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
-        fail_tags: ['any']
+        fail_tags: ['any'],
+        exclude_paths: ['spec']
       }
     end
   rescue LoadError

--- a/libraries/provider_docker_service_systemd.rb
+++ b/libraries/provider_docker_service_systemd.rb
@@ -6,11 +6,11 @@ class Chef
         if Chef::Provider.respond_to?(:provides)
           provides :docker_service, platform: 'fedora'
 
-          provides :docker_service, platform: %w(redhat centos scientific) do |node|
+          provides :docker_service, platform: %w(redhat centos scientific) do |node| # ~FC005
             node['platform_version'].to_f >= 7.0
           end
 
-          provides :docker_service, platform: %w(debian) do |node|
+          provides :docker_service, platform: 'debian' do |node|
             node['platform_version'].to_f >= 8.0
           end
 


### PR DESCRIPTION
set foodcritic to fail on any tag during a travis-ci build, currently foodcritic just complains but returns 0 allowing the build to continue. 

removed the ignore on FC009 tag since that rule passes with the current code.

updating rake and travis-ci to be using the same args passed into foodcritic

foodcritic was complaining about the way platforms were passed, i think the current solution is the cleanest so added an ignore comment.