### PR TITLE
Fixed version detection of Docker version for rhel >= 7 to return 1.7…

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -80,6 +80,7 @@ module DockerHelpers
       return '1.6.2' if node['platform'] == 'amazon'
       return '1.6.2' if node['platform'] == 'ubuntu' && node['platform_version'].to_f < 15.04
       return '1.6.2' if node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7
+      return '1.7.1' if node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 7
       return '1.6.2' if node['platform_family'] == 'debian' && node['platform_version'].to_i <= 7
       '1.8.2'
     end


### PR DESCRIPTION
….1, so that the Docker daemon option is correctly selected on RHEL/CENTOS 7 and above.