### PR TITLE
Replace all occurences of `docker_log` helper with `docker_service.logfile`.

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -39,10 +39,6 @@ module DockerHelpers
       node['kernel']['name']
     end
 
-    def docker_log
-      '/var/log/docker.log'
-    end
-
     def docker_name
       'docker'
     end

--- a/libraries/provider_docker_service_execute.rb
+++ b/libraries/provider_docker_service_execute.rb
@@ -14,7 +14,7 @@ class Chef
           # to manually fork it from the shell with &
           # https://github.com/docker/docker/issues/2758
           bash 'start docker' do
-            code "#{docker_daemon_cmd} &>> #{docker_log} &"
+            code "#{docker_daemon_cmd} &>> #{new_resource.logfile} &"
             environment 'HTTP_PROXY' => new_resource.http_proxy,
                         'HTTPS_PROXY' => new_resource.https_proxy,
                         'NO_PROXY' => new_resource.no_proxy,

--- a/templates/default/sysvinit/docker.erb
+++ b/templates/default/sysvinit/docker.erb
@@ -34,8 +34,8 @@ pidfile="<%= @pidfile %>"
 pidfile="/var/run/$prog.pid"
 <% end -%>
 lockfile="/var/lock/subsys/$prog"
-<% if @config.docker_log -%>
-logfile="<%= @config.docker_log %>"
+<% if @config.logfile -%>
+logfile="<%= @config.logfile %>"
 <% else -%>
 logfile="/var/log/$prog"
 <% end -%>

--- a/templates/default/upstart/etc.default.docker.erb
+++ b/templates/default/upstart/etc.default.docker.erb
@@ -3,7 +3,7 @@
 # Customize location of Docker binary (especially for development testing).
 DOCKER="<%= @docker_bin %>"
 
-<% if @config.docker_log %>
+<% if @config.logfile %>
 DOCKER_LOGFILE=<%= @config.logfile %>
 <% end %>
 


### PR DESCRIPTION
After trying out version 1.0.35 of this cookbook on ubuntu 14.04 (upstart), I found out that the chef-run was broken because of:

```sh
Chef::Mixin::Template::TemplateError (undefined method `docker_log' for Chef::Resource::DockerService) on line #6:

  4: DOCKER="<%= @docker_bin %>"
  5: 
  6: <% if @config.docker_log %>
  7: DOCKER_LOGFILE=<%= @config.logfile %>
  8: <% end %>

```

So I made this PR to replace all occurrences of the `docker_log` helper (which returned the hardcoded `/var/log/docker.log` string) to use the newly introduced docker_service.logfile attribute (with the same default value).