### PR TITLE
Fix template error for sysvinit

### DIFF
--- a/libraries/provider_docker_service_sysvinit.rb
+++ b/libraries/provider_docker_service_sysvinit.rb
@@ -22,6 +22,7 @@ class Chef
             cookbook 'docker'
             variables(
               config: new_resource,
+              docker_bin: docker_bin,
               docker_daemon_arg: docker_daemon_arg,
               docker_opts: docker_opts,
               pidfile: parsed_pidfile

--- a/templates/default/sysvinit/docker.erb
+++ b/templates/default/sysvinit/docker.erb
@@ -25,7 +25,7 @@
 . /etc/rc.d/init.d/functions
 <% end %>
 
-exec="<%= @config.docker_bin %>"
+exec="<%= @docker_bin %>"
 prog="docker"
 unshare=/usr/bin/unshare
 <% if @pidfile -%>


### PR DESCRIPTION
The template for the sysvinit script was broken on CentOS/Amazon Linux. In this commit, it's now passed `docker_bin` in similar fashion as the other templates for upstart and systemd.