### PR TITLE
fix for failed tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,12 @@ section below for more information.
 ```ruby
 docker_service 'tls_test:2376' do
   host ["tcp://#{node['ipaddress']}:2376", 'unix:///var/run/docker.sock']
-  tlscacert '/path/to/ca.pem'
-  tlscert '/path/to/server.pem'
-  tlskey '/path/to/serverkey.pem'
-  tlsverify true
+  tls_verify true
+  tls_ca_cert '/path/to/ca.pem'
+  tls_server_cert '/path/to/server.pem'
+  tls_server_key '/path/to/serverkey.pem'
+  tls_client_cert '/path/to/client.pem'
+  tls_client_key '/path/to/clientkey.pem'
   provider Chef::Provider::DockerService::Systemd
   action [:create, :start]
 end
@@ -239,10 +241,12 @@ the options found in the
 - `selinux_enabled` - Enable selinux support
 - `storage_opt` - Set storage driver options
 - `tls` - Use TLS; implied by --tlsverify
-- `tlscacert` - Trust certs signed only by this CA
-- `tlscert` - Path to TLS certificate file
-- `tlskey` - Path to TLS key file
-- `tlsverify` - Use TLS and verify the remote
+- `tls_verify` - Use TLS and verify the remote
+- `tls_ca_cert` - Trust certs signed only by this CA
+- `tls_server_cert` - Path to TLS certificate file for docker service
+- `tls_server_key` - Path to TLS key file for docker service
+- `tls_client_cert` - Path to TLS certificate file for docker cli
+- `tls_client_key` - Path to TLS key file for docker cli
 - `default_ulimit` - Set default ulimit settings for containers
 - `http_proxy` - ENV variable set before for Docker daemon starts
 - `https_proxy` - ENV variable set before for Docker daemon starts

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -102,7 +102,7 @@ module DockerHelpers
     end
 
     def docker_daemon_cmd
-      [docker_bin, docker_daemon_arg, docker_opts].join(' ')
+      [docker_bin, docker_daemon_arg, docker_daemon_opts].join(' ')
     end
 
     def docker_wait_ready
@@ -161,7 +161,7 @@ module DockerHelpers
       Array(new_resource.default_ulimit)
     end
 
-    def docker_opts
+    def docker_daemon_opts
       opts = []
       opts << "--api-cors-header=#{new_resource.api_cors_header}" if new_resource.api_cors_header
       opts << "--bridge=#{new_resource.bridge}" if new_resource.bridge

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -168,8 +168,8 @@ module DockerHelpers
       opts = []
       opts << "--host=#{parsed_connect_host}" if parsed_connect_host
       if parsed_connect_host =~ /^tcp:/
-        opts << "--tls=#{new_resource.tls}"
-        opts << "--tlsverify=#{new_resource.tls_verify}"
+        opts << "--tls=#{new_resource.tls}" unless new_resource.tls.nil?
+        opts << "--tlsverify=#{new_resource.tls_verify}" unless new_resource.tls_verify.nil?
         opts << "--tlscacert=#{new_resource.tls_ca_cert}" if new_resource.tls_ca_cert
         opts << "--tlscert=#{new_resource.tls_client_cert}" if new_resource.tls_client_cert
         opts << "--tlskey=#{new_resource.tls_client_key}" if new_resource.tls_client_key
@@ -209,8 +209,8 @@ module DockerHelpers
       parsed_storage_driver.each { |s| opts << "--storage-driver=#{s}" } if new_resource.storage_driver
       opts << '--selinux-enabled=true' if new_resource.selinux_enabled
       parsed_storage_opts.each { |storage_opt| opts << "--storage-opt=#{storage_opt}" }
-      opts << "--tls=#{new_resource.tls}"
-      opts << "--tlsverify=#{new_resource.tls_verify}"
+      opts << "--tls=#{new_resource.tls}" unless new_resource.tls.nil?
+      opts << "--tlsverify=#{new_resource.tls_verify}" unless new_resource.tls_verify.nil?
       opts << "--tlscacert=#{new_resource.tls_ca_cert}" if new_resource.tls_ca_cert
       opts << "--tlscert=#{new_resource.tls_server_cert}" if new_resource.tls_server_cert
       opts << "--tlskey=#{new_resource.tls_server_key}" if new_resource.tls_server_key

--- a/libraries/provider_docker_service.rb
+++ b/libraries/provider_docker_service.rb
@@ -23,17 +23,13 @@ class Chef
       def load_current_resource
         @current_resource = Chef::Resource::DockerService.new(new_resource.name)
 
-        # FIXME: remove this line
-        Excon.defaults[:ssl_verify_peer] = false
+        Docker.url = parsed_connect_host if parsed_connect_host
 
-        cert_path = ::File.dirname new_resource.tlscacert if new_resource.tlscacert
-
-        unless new_resource.host.nil? || cert_path.nil?
-          Docker.url = new_resource.host
+        if parsed_connect_host =~ /^tcp:/ && new_resource.tls_ca_cert
           Docker.options = {
-            ssl_ca_file: ::File.join(cert_path, 'ca.pem'),
-            client_cert: ::File.join(cert_path, 'cert.pem'),
-            client_key: ::File.join(cert_path, 'key.pem'),
+            ssl_ca_file: new_resource.tls_ca_cert,
+            client_cert: new_resource.tls_client_cert,
+            client_key: new_resource.tls_client_key,
             scheme: 'https'
           }
         end

--- a/libraries/provider_docker_service_execute.rb
+++ b/libraries/provider_docker_service_execute.rb
@@ -31,23 +31,7 @@ class Chef
           end
 
           # loop until docker socker is available
-          bash 'docker-wait-ready' do
-            env_h = {}
-            env_h['DOCKER_HOST'] = new_resource.host unless new_resource.host.nil?
-            env_h['DOCKER_CERT_PATH'] = ::File.dirname(new_resource.tlscacert) unless new_resource.tlscacert.nil?
-            env_h['DOCKER_TLS_VERIFY'] = '1' if new_resource.tlsverify == true
-            environment env_h
-            code <<-EOF
-            while /bin/true; do
-              docker ps | head -n 1 | grep ^CONTAINER
-              if [ $? -eq 0 ]; then
-                break
-              fi
-              sleep 1
-            done
-            EOF
-            not_if { docker_running? }
-          end
+          docker_wait_ready
         end
 
         action :stop do

--- a/libraries/provider_docker_service_systemd.rb
+++ b/libraries/provider_docker_service_systemd.rb
@@ -67,23 +67,7 @@ class Chef
           end
 
           # loop until docker socker is available
-          bash 'docker-wait-ready' do
-            env_h = {}
-            env_h['DOCKER_HOST'] = new_resource.host unless new_resource.host.nil?
-            env_h['DOCKER_CERT_PATH'] = ::File.dirname(new_resource.tlscacert) unless new_resource.tlscacert.nil?
-            env_h['DOCKER_TLS_VERIFY'] = '1' if new_resource.tlsverify == true
-            environment env_h
-            code <<-EOF
-            while /bin/true; do
-              docker ps | head -n 1 | grep ^CONTAINER
-              if [ $? -eq 0 ]; then
-                break
-              fi
-              sleep 1
-            done
-            EOF
-            not_if 'docker ps | head -n 1 | grep ^CONTAINER', environment: env_h
-          end
+          docker_wait_ready
         end
 
         action :stop do

--- a/libraries/provider_docker_service_systemd.rb
+++ b/libraries/provider_docker_service_systemd.rb
@@ -33,7 +33,7 @@ class Chef
               config: new_resource,
               docker_bin: docker_bin,
               docker_daemon_arg: docker_daemon_arg,
-              docker_opts: docker_opts
+              docker_daemon_opts: docker_daemon_opts
             )
             cookbook 'docker'
             notifies :run, 'execute[systemctl daemon-reload]', :immediately

--- a/libraries/provider_docker_service_sysvinit.rb
+++ b/libraries/provider_docker_service_sysvinit.rb
@@ -42,26 +42,7 @@ class Chef
           end
 
           # loop until docker socker is available
-          bash 'docker-wait-ready' do
-            env_h = {}
-            env_h['DOCKER_HOST'] = new_resource.host unless new_resource.host.nil?
-            env_h['DOCKER_CERT_PATH'] = ::File.dirname(new_resource.tlscacert) unless new_resource.tlscacert.nil?
-            env_h['DOCKER_TLS_VERIFY'] = '1' if new_resource.tlsverify == true
-            environment env_h
-            code <<-EOF
-            echo "DOCKER_HOST: $DOCKER_HOST"
-            echo "DOCKER_CERT_PATH: $DOCKER_CERT_PATH"
-            echo "DOCKER_TLS_VERIFY: $DOCKER_TLS_VERIFY"
-            while /bin/true; do
-              docker ps | head -n 1 | grep ^CONTAINER
-              if [ $? -eq 0 ]; then
-                break
-              fi
-              sleep 1
-            done
-            EOF
-            not_if 'docker ps | head -n 1 | grep ^CONTAINER', environment: env_h
-          end
+          docker_wait_ready
         end
 
         action :stop do

--- a/libraries/provider_docker_service_sysvinit.rb
+++ b/libraries/provider_docker_service_sysvinit.rb
@@ -27,8 +27,8 @@ class Chef
               docker_host: new_resource.host,
               docker_name: docker_name,
               docker_daemon_opts: docker_daemon_opts,
-              docker_tlscacert: new_resource.tlscacert,
-              docker_tlsverify: new_resource.tlsverify,
+              docker_tls_ca_cert: new_resource.tls_ca_cert,
+              docker_tls_verify: new_resource.tls_verify,
               pidfile: parsed_pidfile
             )
             action :create
@@ -60,8 +60,8 @@ class Chef
               docker_host: new_resource.host,
               docker_name: docker_name,
               docker_daemon_opts: docker_daemon_opts,
-              docker_tlscacert: new_resource.tlscacert,
-              docker_tlsverify: new_resource.tlsverify,
+              docker_tls_ca_cert: new_resource.tls_ca_cert,
+              docker_tls_verify: new_resource.tls_verify,
               pidfile: parsed_pidfile
             )
             action :create

--- a/libraries/provider_docker_service_sysvinit.rb
+++ b/libraries/provider_docker_service_sysvinit.rb
@@ -26,7 +26,7 @@ class Chef
               docker_daemon_cmd: docker_daemon_cmd,
               docker_host: new_resource.host,
               docker_name: docker_name,
-              docker_opts: docker_opts,
+              docker_daemon_opts: docker_daemon_opts,
               docker_tlscacert: new_resource.tlscacert,
               docker_tlsverify: new_resource.tlsverify,
               pidfile: parsed_pidfile
@@ -59,7 +59,7 @@ class Chef
               docker_daemon_cmd: docker_daemon_cmd,
               docker_host: new_resource.host,
               docker_name: docker_name,
-              docker_opts: docker_opts,
+              docker_daemon_opts: docker_daemon_opts,
               docker_tlscacert: new_resource.tlscacert,
               docker_tlsverify: new_resource.tlsverify,
               pidfile: parsed_pidfile

--- a/libraries/provider_docker_service_upstart.rb
+++ b/libraries/provider_docker_service_upstart.rb
@@ -44,23 +44,7 @@ class Chef
           end
 
           # loop until docker socker is available
-          bash 'docker-wait-ready' do
-            env_h = {}
-            env_h['DOCKER_HOST'] = new_resource.host unless new_resource.host.nil?
-            env_h['DOCKER_CERT_PATH'] = ::File.dirname(new_resource.tlscacert) unless new_resource.tlscacert.nil?
-            env_h['DOCKER_TLS_VERIFY'] = '1' if new_resource.tlsverify == true
-            environment env_h
-            code <<-EOF
-            while /bin/true; do
-              docker ps | head -n 1 | grep ^CONTAINER
-              if [ $? -eq 0 ]; then
-                break
-              fi
-              sleep 1
-            done
-            EOF
-            not_if 'docker ps | head -n 1 | grep ^CONTAINER', environment: env_h
-          end
+          docker_wait_ready
         end
 
         action :stop do

--- a/libraries/provider_docker_service_upstart.rb
+++ b/libraries/provider_docker_service_upstart.rb
@@ -17,7 +17,7 @@ class Chef
             variables(
               config: new_resource,
               docker_bin: docker_bin,
-              docker_opts: docker_opts
+              docker_daemon_opts: docker_daemon_opts
             )
             cookbook 'docker'
             action :create

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -52,11 +52,13 @@ class Chef
       attribute :storage_driver, kind_of: [String, Array], default: nil
       attribute :selinux_enabled, kind_of: [TrueClass, FalseClass], default: nil
       attribute :storage_opts, kind_of: [String, Array], default: []
-      attribute :tls, kind_of: [TrueClass, FalseClass], default: nil
-      attribute :tlscacert, kind_of: String, default: nil
-      attribute :tlscert, kind_of: String, default: nil
-      attribute :tlskey, kind_of: String, default: nil
-      attribute :tlsverify, kind_of: [TrueClass, FalseClass], default: nil
+      attribute :tls, kind_of: [TrueClass, FalseClass], default: true
+      attribute :tls_verify, kind_of: [TrueClass, FalseClass], default: true
+      attribute :tls_ca_cert, kind_of: String, default: nil
+      attribute :tls_server_cert, kind_of: String, default: nil
+      attribute :tls_server_key, kind_of: String, default: nil
+      attribute :tls_client_cert, kind_of: String, default: nil
+      attribute :tls_client_key, kind_of: String, default: nil
       attribute :default_ulimit, kind_of: [String, Array], default: nil
       attribute :userland_proxy, kind_of: [TrueClass, FalseClass], default: nil
 
@@ -68,6 +70,11 @@ class Chef
 
       # logging
       attribute :logfile, kind_of: String, default: '/var/log/docker.log'
+
+      alias_method :tlscacert, :tls_ca_cert
+      alias_method :tlscert, :tls_server_cert
+      alias_method :tlskey, :tls_server_key
+      alias_method :tlsverify, :tls_verify
 
       include DockerHelpers
     end

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -52,7 +52,7 @@ class Chef
       attribute :storage_driver, kind_of: [String, Array], default: nil
       attribute :selinux_enabled, kind_of: [TrueClass, FalseClass], default: nil
       attribute :storage_opts, kind_of: [String, Array], default: []
-      attribute :tls, kind_of: [TrueClass, FalseClass], default: false
+      attribute :tls, kind_of: [TrueClass, FalseClass], default: nil
       attribute :tlscacert, kind_of: String, default: nil
       attribute :tlscert, kind_of: String, default: nil
       attribute :tlskey, kind_of: String, default: nil

--- a/libraries/resource_docker_service.rb
+++ b/libraries/resource_docker_service.rb
@@ -52,8 +52,8 @@ class Chef
       attribute :storage_driver, kind_of: [String, Array], default: nil
       attribute :selinux_enabled, kind_of: [TrueClass, FalseClass], default: nil
       attribute :storage_opts, kind_of: [String, Array], default: []
-      attribute :tls, kind_of: [TrueClass, FalseClass], default: true
-      attribute :tls_verify, kind_of: [TrueClass, FalseClass], default: true
+      attribute :tls, kind_of: [TrueClass, FalseClass], default: nil
+      attribute :tls_verify, kind_of: [TrueClass, FalseClass], default: nil
       attribute :tls_ca_cert, kind_of: String, default: nil
       attribute :tls_server_cert, kind_of: String, default: nil
       attribute :tls_server_key, kind_of: String, default: nil

--- a/templates/default/systemd/docker.service.erb
+++ b/templates/default/systemd/docker.service.erb
@@ -23,7 +23,7 @@ ExecStartPre=/sbin/sysctl -w net.ipv4.ip_forward=1
 <% if @config.ipv6_forward %>
 ExecStartPre=/sbin/sysctl -w net.ipv6.conf.all.forwarding=1
 <% end %>
-ExecStart=<%= @docker_bin %> <%= @docker_daemon_arg %> <%= @docker_opts.join(' ') %>
+ExecStart=<%= @docker_bin %> <%= @docker_daemon_arg %> <%= @docker_daemon_opts.join(' ') %>
 Restart=always
 MountFlags=slave
 LimitNOFILE=1048576

--- a/templates/default/sysvinit/docker.erb
+++ b/templates/default/sysvinit/docker.erb
@@ -37,10 +37,10 @@ PID_DELAY=60
 <% if @docker_host %>
 export DOCKER_HOST=<%= @docker_host %>
 <% end %>
-<% if @docker_tlscacert %>
-export DOCKER_CERT_PATH=`dirname <%= @docker_tlscacert %>`
+<% if @docker_tls_ca_cert %>
+export DOCKER_CERT_PATH=`dirname <%= @docker_tls_ca_cert %>`
 <% end %>
-<% if @docker_tlsverify %>
+<% if @docker_tls_verify %>
 export DOCKER_TLS_VERIFY=1
 <% end %>
 <% if @pidfile -%>
@@ -63,9 +63,9 @@ pid_exists() {
     PID_EXISTS=1
     if [ -f $pid_file ]; then
         DOCKER_PID=`cat $pid_file 2>/dev/null`
-	      if [ -n "$DOCKER_PID" ] && [ -d "/proc/$DOCKER_PID" ] ; then
-	          PID_EXISTS=0
-	      fi
+        if [ -n "$DOCKER_PID" ] && [ -d "/proc/$DOCKER_PID" ] ; then
+            PID_EXISTS=0
+        fi
     fi
     return $PID_EXISTS
 }
@@ -212,7 +212,7 @@ start() {
         fi
 
         sleep 1
-	      let TIMEOUT=${TIMEOUT}-1
+        let TIMEOUT=${TIMEOUT}-1
     done
 
     if running; then
@@ -223,13 +223,13 @@ start() {
         # Handle startup failure
         print_start_failure
         return 3
-	  elif [ $TIMEOUT -eq 0 ]; then
+    elif [ $TIMEOUT -eq 0 ]; then
         # Handle timeout
         print_start_failure
         # clean up
         kill $start_pid 2>/dev/null
-	      return 1
-	  fi
+        return 1
+    fi
 }
 
 # Status of <%= @mysql_name %>
@@ -257,7 +257,7 @@ stop() {
             if running; then
             sleep 1
             fi
-	          let TIMEOUT=${TIMEOUT}-1
+            let TIMEOUT=${TIMEOUT}-1
         done
 
         return $kstat

--- a/templates/default/upstart/docker.conf.erb
+++ b/templates/default/upstart/docker.conf.erb
@@ -17,51 +17,51 @@ pre-start script
   /sbin/sysctl -w net.ipv6.conf.all.forwarding=1 > /dev/null 2>&1
   <% end %>
 
-	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
-	if grep -v '^#' /etc/fstab | grep -q cgroup \
-		|| [ ! -e /proc/cgroups ] \
-		|| [ ! -d /sys/fs/cgroup ]; then
-		exit 0
-	fi
-	if ! mountpoint -q /sys/fs/cgroup; then
-		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
-	fi
-	(
-		cd /sys/fs/cgroup
-		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
-			mkdir -p $sys
-			if ! mountpoint -q $sys; then
-				if ! mount -n -t cgroup -o $sys cgroup $sys; then
-					rmdir $sys || true
-				fi
-			fi
-		done
-	)
+  # see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+  if grep -v '^#' /etc/fstab | grep -q cgroup \
+    || [ ! -e /proc/cgroups ] \
+    || [ ! -d /sys/fs/cgroup ]; then
+    exit 0
+  fi
+  if ! mountpoint -q /sys/fs/cgroup; then
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+  fi
+  (
+    cd /sys/fs/cgroup
+    for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+      mkdir -p $sys
+      if ! mountpoint -q $sys; then
+        if ! mount -n -t cgroup -o $sys cgroup $sys; then
+          rmdir $sys || true
+        fi
+      fi
+    done
+  )
 end script
 
 script
-	# modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
-	DOCKER=/usr/bin/$UPSTART_JOB
-	DOCKER_OPTS=
-	if [ -f /etc/default/$UPSTART_JOB ]; then
-		. /etc/default/$UPSTART_JOB
-	fi
-	exec "$DOCKER" <%= @docker_daemon_arg %> $DOCKER_OPTS >> <%= @config.logfile %>
+  # modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
+  DOCKER=/usr/bin/$UPSTART_JOB
+  DOCKER_DAEMON_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  exec "$DOCKER" <%= @docker_daemon_arg %> $DOCKER_DAEMON_OPTS >> <%= @config.logfile %>
 end script
 
 # Don't emit "started" event until docker.sock is ready.
 # See https://github.com/docker/docker/issues/6647
 post-start script
-	DOCKER_OPTS=
-	if [ -f /etc/default/$UPSTART_JOB ]; then
-		. /etc/default/$UPSTART_JOB
-	fi
-	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
-		while ! [ -e /var/run/docker.sock ]; do
-			initctl status $UPSTART_JOB | grep -q "stop/" && exit 1
-			echo "Waiting for /var/run/docker.sock"
-			sleep 0.1
-		done
-		echo "/var/run/docker.sock is up"
-	fi
+  DOCKER_DAEMON_OPTS=
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+  if ! printf "%s" "$DOCKER_DAEMON_OPTS" | grep -qE -e '-H|--host'; then
+    while ! [ -e /var/run/docker.sock ]; do
+      initctl status $UPSTART_JOB | grep -q "stop/" && exit 1
+      echo "Waiting for /var/run/docker.sock"
+      sleep 0.1
+    done
+    echo "/var/run/docker.sock is up"
+  fi
 end script

--- a/templates/default/upstart/etc.default.docker.erb
+++ b/templates/default/upstart/etc.default.docker.erb
@@ -8,7 +8,7 @@ DOCKER_LOGFILE=<%= @config.logfile %>
 <% end %>
 
 # Use DOCKER_OPTS to modify the daemon startup options.
-DOCKER_OPTS="<%= @docker_opts.join(' ') %>"
+DOCKER_DAEMON_OPTS="<%= @docker_daemon_opts.join(' ') %>"
 # FIXME
 
 <% if @config.pidfile %>

--- a/test/cookbooks/docker_service_test/recipes/tls.rb
+++ b/test/cookbooks/docker_service_test/recipes/tls.rb
@@ -122,10 +122,12 @@ end
 # start docker service listening on TCP port
 docker_service 'tls_test:2376' do
   host 'tcp://127.0.0.1:2376'
-  tlscacert "#{caroot}/ca.pem"
-  tlscert "#{caroot}/server.pem"
-  tlskey "#{caroot}/serverkey.pem"
-  tlsverify true
+  tls_verify true
+  tls_ca_cert "#{caroot}/ca.pem"
+  tls_server_cert "#{caroot}/server.pem"
+  tls_server_key "#{caroot}/serverkey.pem"
+  tls_client_cert "#{caroot}/cert.pem"
+  tls_client_key "#{caroot}/key.pem"
   provider Chef::Provider::DockerService::Execute if execute_service_manager
   action [:create, :start]
 end


### PR DESCRIPTION
a lot of changes here. i did some cleanup in a couple of commits for clarity prior to the big tls changes.

i removed using the environment variables for the docker command since it doesnt match exact with the api. if a user had a cert and key in different locations it would have failed. there is now a docker_cmd to use when we need to shell out to docker cli. this takes care of any options we need to specify (tls and host atm).

the docker daemon uses multiple host commands, but the client only uses one so i created a parsing function for the connect_host. this should be expanded on later and should prioritize using the socket over tcp. for now though the function just returns the first element.

let me know how it tests out with test-kitchen.

resolves #468