### PR TITLE
per-resource docker host

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,16 @@ docker_container 'syslogger' do
 end
 ```
 
+Connect to an external docker daemon and create a container
+
+```ruby
+docker_container 'external_daemon' do
+  repo 'alpine'
+  host 'tcp://1.2.3.4:2376'
+  action :create
+end
+```
+
 #### Properties
 
 Most `docker_container` properties are the `snake_case` version of the
@@ -867,6 +877,8 @@ Most `docker_container` properties are the `snake_case` version of the
   `/etc/hosts` in the form `['host_a:10.9.8.7', 'host_b:10.9.8.6']`
 - `force` - A boolean to use in container operations that support a
   `force` option. Defaults to `false`
+- `host` - A string containing the host the API should communicate with.
+  Defaults to local `docker_service`.
 - `host_name` - The hostname for the container.
 - `links` - An array of source container/alias pairs to link the
   container to in the form `[container_a:www', container_b:db']`

--- a/README.md
+++ b/README.md
@@ -380,6 +380,15 @@ docker_image 'my.computers.biz:5043/someara/hello-again' do
 end
 ```
 
+Connect to an external docker daemon and pull an image
+
+```ruby
+docker_image 'alpine' do
+  host 'tcp://127.0.0.1:2376'
+  tag '2.7'
+end
+```
+
 #### Properties
 The `docker_image` resource properties mostly corresponds to the
 [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api_v1.20/#2-2-images)
@@ -415,6 +424,8 @@ registry vs a private one.
   (default behavior) - Defaults to `true`
 - `read_timeout` - May need to increase for long image builds/pulls
 - `write_timeout` - May need to increase for long image builds/pulls
+- `host` - A string containing the host the API should communicate with.
+  Defaults to local `docker_service`.
 
 #### Actions
 The following actions are available for a `docker_image` resource.

--- a/libraries/helpers_connection.rb
+++ b/libraries/helpers_connection.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+module DockerHelpers
+  module Connection
+    def parsed_host
+      new_resource.host || Docker.url
+    end
+
+    def parsed_options
+      opts = {}
+      opts['read_timeout'] = new_resource.read_timeout unless new_resource.read_timeout.nil?
+      opts['write_timeout'] = new_resource.write_timeout unless new_resource.write_timeout.nil?
+      opts
+    end
+  end
+end

--- a/libraries/helpers_connection.rb
+++ b/libraries/helpers_connection.rb
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
-
 module DockerHelpers
   module Connection
-    def parsed_host
+    def parsed_connect_host
       new_resource.host || Docker.url
     end
 
-    def parsed_options
+    def parsed_connect_options
       opts = {}
       opts['read_timeout'] = new_resource.read_timeout unless new_resource.read_timeout.nil?
       opts['write_timeout'] = new_resource.write_timeout unless new_resource.write_timeout.nil?

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -6,17 +6,23 @@ module DockerHelpers
     # Helper methods
     ################
 
-    def api_timeouts
-      Docker.options[:read_timeout] = new_resource.read_timeout unless new_resource.read_timeout.nil?
-      Docker.options[:write_timeout] = new_resource.write_timeout unless new_resource.write_timeout.nil?
-    end
-
     # This is called a lot.. maybe this should turn into an instance variable
     def container_created?
-      Docker::Container.get(new_resource.container_name)
+      Docker::Container.get(new_resource.container_name, @conn)
       return true
     rescue Docker::Error::NotFoundError
       return false
+    end
+
+    def parsed_host
+      new_resource.host || Docker.url
+    end
+
+    def parsed_options
+      opts = {}
+      opts['read_timeout'] = new_resource.read_timeout unless new_resource.read_timeout.nil?
+      opts['write_timeout'] = new_resource.write_timeout unless new_resource.write_timeout.nil?
+      opts
     end
 
     # Use this instead of new_resource.repo

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 module DockerHelpers
   module Container
     ################

--- a/libraries/helpers_container.rb
+++ b/libraries/helpers_container.rb
@@ -14,17 +14,6 @@ module DockerHelpers
       return false
     end
 
-    def parsed_host
-      new_resource.host || Docker.url
-    end
-
-    def parsed_options
-      opts = {}
-      opts['read_timeout'] = new_resource.read_timeout unless new_resource.read_timeout.nil?
-      opts['write_timeout'] = new_resource.write_timeout unless new_resource.write_timeout.nil?
-      opts
-    end
-
     # Use this instead of new_resource.repo
     def parsed_repo
       return new_resource.repo if new_resource.repo

--- a/libraries/helpers_image.rb
+++ b/libraries/helpers_image.rb
@@ -1,0 +1,109 @@
+module DockerHelpers
+  module Image
+    ################
+    # Helper methods
+    ################
+
+    def build_from_directory
+      i = Docker::Image.build_from_dir(
+        new_resource.source,
+        {
+          'nocache' => new_resource.nocache,
+          'rm' => new_resource.rm
+        },
+        @conn
+      )
+      i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
+    end
+
+    def build_from_dockerfile
+      i = Docker::Image.build(
+        IO.read(new_resource.source),
+        {
+          'nocache' => new_resource.nocache,
+          'rm' => new_resource.rm
+        },
+        @conn
+      )
+      i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
+    end
+
+    def build_from_tar
+      i = Docker::Image.build_from_tar(
+        ::File.open(new_resource.source, 'r'),
+        {
+          'nocache' => new_resource.nocache,
+          'rm' => new_resource.rm
+        },
+        @conn
+      )
+      i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
+    end
+
+    def build_image
+      if ::File.directory?(new_resource.source)
+        build_from_directory
+      elsif ::File.extname(new_resource.source) == '.tar'
+        build_from_tar
+      else
+        build_from_dockerfile
+      end
+    end
+
+    def image_identifier
+      "#{new_resource.repo}:#{new_resource.tag}"
+    end
+
+    def import_image
+      retries ||= new_resource.api_retries
+      i = Docker::Image.import(new_resource.source, {}, @conn)
+      i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
+    rescue Docker::Error => e
+      retry unless (retries -= 1).zero?
+      raise e.message
+    end
+
+    def pull_image
+      begin
+        retries ||= new_resource.api_retries
+
+        registry_host = parse_registry_host(new_resource.repo)
+        creds = node.run_state['docker_auth'] && node.run_state['docker_auth'][registry_host]
+
+        original_image = Docker::Image.get(image_identifier, {}, @conn) if Docker::Image.exist?(image_identifier, {}, @conn)
+        new_image = Docker::Image.create({ 'fromImage' => image_identifier }, creds, @conn)
+      rescue Docker::Error => e
+        retry unless (retries -= 1).zero?
+        raise e.message
+      end
+
+      !(original_image && original_image.id.start_with?(new_image.id))
+    end
+
+    def push_image
+      retries ||= new_resource.api_retries
+      i = Docker::Image.get(image_identifier, {}, @conn)
+      i.push
+    rescue Docker::Error => e
+      retry unless (retries -= 1).zero?
+      raise e.message
+    end
+
+    def remove_image
+      retries ||= new_resource.api_retries
+      i = Docker::Image.get(image_identifier, {}, @conn)
+      i.remove(force: new_resource.force, noprune: new_resource.noprune)
+    rescue Docker::Error => e
+      retry unless (retries -= 1).zero?
+      raise e.message
+    end
+
+    def save_image
+      retries ||= new_resource.api_retries
+      Docker::Image.save(new_resource.repo, new_resource.destination, @conn)
+    rescue Docker::Error, Errno::ENOENT => e
+      retry unless (retries -= 1).zero?
+      raise e.message
+    end
+  end
+end

--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -16,7 +16,7 @@ class Chef
 
       def initialize(*args)
         super
-        @conn = Docker::Connection.new(parsed_host, parsed_options)
+        @conn = Docker::Connection.new(parsed_connect_host, parsed_connect_options)
       end
 
       def load_current_resource

--- a/libraries/provider_docker_container.rb
+++ b/libraries/provider_docker_container.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift *Dir[File.expand_path('../../files/default/vendor/gems/**/lib
 require 'docker'
 require 'shellwords'
 require_relative 'helpers_container'
+require_relative 'helpers_connection'
 
 class Chef
   class Provider
@@ -10,10 +11,15 @@ class Chef
       provides :docker_container if Chef::Provider.respond_to?(:provides)
 
       include DockerHelpers::Container
+      include DockerHelpers::Connection
       use_inline_resources
 
-      def load_current_resource
+      def initialize(*args)
+        super
         @conn = Docker::Connection.new(parsed_host, parsed_options)
+      end
+
+      def load_current_resource
         @api_version = Docker.version['ApiVersion']
 
         @current_resource = Chef::Resource::DockerContainer.new(new_resource.name)

--- a/libraries/provider_docker_image.rb
+++ b/libraries/provider_docker_image.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.unshift *Dir[File.expand_path('../../files/default/vendor/gems/**/lib', __FILE__)]
 require 'docker'
+require_relative 'helpers_image'
 require_relative 'helpers_auth'
+require_relative 'helpers_connection'
 
 class Chef
   class Provider
@@ -8,114 +10,13 @@ class Chef
       # register with the resource resolution system
       provides :docker_image if Chef::Provider.respond_to?(:provides)
 
+      include DockerHelpers::Image
       include DockerHelpers::Authentication
+      include DockerHelpers::Connection
 
-      ################
-      # Helper methods
-      ################
-
-      def api_timeouts
-        Docker.options[:read_timeout] = new_resource.read_timeout unless new_resource.read_timeout.nil?
-        Docker.options[:write_timeout] = new_resource.write_timeout unless new_resource.write_timeout.nil?
-      end
-
-      def build_from_directory
-        i = Docker::Image.build_from_dir(
-          new_resource.source,
-          'nocache' => new_resource.nocache,
-          'rm' => new_resource.rm
-        )
-        i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
-      end
-
-      def build_from_dockerfile
-        i = Docker::Image.build(
-          IO.read(new_resource.source),
-          'nocache' => new_resource.nocache,
-          'rm' => new_resource.rm
-        )
-        i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
-      end
-
-      def build_from_tar
-        i = Docker::Image.build_from_tar(
-          ::File.open(new_resource.source, 'r'),
-          'nocache' => new_resource.nocache,
-          'rm' => new_resource.rm
-        )
-        i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
-      end
-
-      def build_image
-        api_timeouts
-        if ::File.directory?(new_resource.source)
-          build_from_directory
-        elsif ::File.extname(new_resource.source) == '.tar'
-          build_from_tar
-        else
-          build_from_dockerfile
-        end
-      end
-
-      def image_identifier
-        "#{new_resource.repo}:#{new_resource.tag}"
-      end
-
-      def import_image
-        api_timeouts
-        retries ||= new_resource.api_retries
-        i = Docker::Image.import(new_resource.source)
-        i.tag('repo' => new_resource.repo, 'tag' => new_resource.tag, 'force' => new_resource.force)
-      rescue Docker::Error => e
-        retry unless (retries -= 1).zero?
-        raise e.message
-      end
-
-      def pull_image
-        begin
-          retries ||= new_resource.api_retries
-          api_timeouts
-
-          registry_host = parse_registry_host(new_resource.repo)
-          creds = node.run_state['docker_auth'] && node.run_state['docker_auth'][registry_host]
-
-          original_image = Docker::Image.get(image_identifier) if Docker::Image.exist?(image_identifier)
-          new_image = Docker::Image.create({ 'fromImage' => image_identifier }, creds)
-        rescue Docker::Error => e
-          retry unless (retries -= 1).zero?
-          raise e.message
-        end
-
-        !(original_image && original_image.id.start_with?(new_image.id))
-      end
-
-      def push_image
-        api_timeouts
-        retries ||= new_resource.api_retries
-        i = Docker::Image.get(image_identifier)
-        i.push
-      rescue Docker::Error => e
-        retry unless (retries -= 1).zero?
-        raise e.message
-      end
-
-      def remove_image
-        api_timeouts
-        retries ||= new_resource.api_retries
-        i = Docker::Image.get(image_identifier)
-        i.remove(force: new_resource.force, noprune: new_resource.noprune)
-      rescue Docker::Error => e
-        retry unless (retries -= 1).zero?
-        raise e.message
-      end
-
-      def save_image
-        api_timeouts
-        retries ||= new_resource.api_retries
-        Docker::Image.save(new_resource.repo, new_resource.destination)
-      rescue Docker::Error, Errno::ENOENT => e
-        retry unless (retries -= 1).zero?
-        raise e.message
+      def initialize(*args)
+        super
+        @conn = Docker::Connection.new(parsed_connect_host, parsed_connect_options)
       end
 
       #########
@@ -128,13 +29,13 @@ class Chef
       end
 
       action :build_if_missing do
-        next if Docker::Image.exist?(image_identifier)
+        next if Docker::Image.exist?(image_identifier, {}, @conn)
         action_build
         new_resource.updated_by_last_action(true)
       end
 
       action :import do
-        next if Docker::Image.exist?(image_identifier)
+        next if Docker::Image.exist?(image_identifier, {}, @conn)
         import_image
         new_resource.updated_by_last_action(true)
       end
@@ -145,7 +46,7 @@ class Chef
       end
 
       action :pull_if_missing do
-        next if Docker::Image.exist?(image_identifier)
+        next if Docker::Image.exist?(image_identifier, {}, @conn)
         action_pull
       end
 
@@ -155,7 +56,7 @@ class Chef
       end
 
       action :remove do
-        next unless Docker::Image.exist?(image_identifier)
+        next unless Docker::Image.exist?(image_identifier, {}, @conn)
         remove_image
         new_resource.updated_by_last_action(true)
       end

--- a/libraries/resource_docker_container.rb
+++ b/libraries/resource_docker_container.rb
@@ -32,6 +32,7 @@ class Chef
       attribute :extra_hosts, kind_of: [String, Array, NilClass], default: nil
       attribute :exposed_ports, kind_of: Hash, default: nil
       attribute :force, kind_of: [TrueClass, FalseClass], default: false
+      attribute :host, kind_of: String, default: nil
       attribute :host_name, kind_of: String, default: nil
       attribute :labels, kind_of: [String, Array, Hash], default: nil
       attribute :links, kind_of: [String, Array, NilClass], default: nil # FIXME: add validate proc

--- a/libraries/resource_docker_image.rb
+++ b/libraries/resource_docker_image.rb
@@ -13,6 +13,7 @@ class Chef
       attribute :api_retries, kind_of: Fixnum, default: 3
       attribute :destination, kind_of: String, default: nil
       attribute :force, kind_of: [TrueClass, FalseClass], default: false
+      attribute :host, kind_of: String, default: nil
       attribute :nocache, kind_of: [TrueClass, FalseClass], default: false
       attribute :noprune, kind_of: [TrueClass, FalseClass], default: false
       attribute :read_timeout, kind_of: [Fixnum, NilClass], default: 120

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -914,6 +914,17 @@ docker_container 'overrides-2' do
 end
 
 #################
+# host override
+#################
+
+docker_container 'host_override' do
+  repo 'alpine'
+  host 'tcp://127.0.0.1:2376'
+  command 'ls -la /'
+  action :create
+end
+
+#################
 # logging drivers
 #################
 

--- a/test/cookbooks/docker_test/recipes/default.rb
+++ b/test/cookbooks/docker_test/recipes/default.rb
@@ -1,5 +1,5 @@
 docker_service 'default' do
-  tls false
+  host ['unix:///var/run/docker.sock', 'tcp://127.0.0.1:2376']
   version node['docker']['version']
   # storage_driver 'overlay'
   action [:create, :start]

--- a/test/cookbooks/docker_test/recipes/image.rb
+++ b/test/cookbooks/docker_test/recipes/image.rb
@@ -27,6 +27,12 @@ docker_image 'alpine' do
   write_timeout 60
 end
 
+# host override
+docker_image 'alpine' do
+  host 'tcp://127.0.0.1:2376'
+  tag '2.7'
+end
+
 #########
 # :remove
 #########

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -714,3 +714,9 @@ describe command("docker inspect -f '{{ .HostConfig.LogConfig.Config }}' syslogg
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/syslog-tag:container-syslogger/) }
 end
+
+# docker_container[host_override]
+
+describe command("docker ps -af 'name=host_override'") do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -58,6 +58,11 @@ describe command('docker images') do
   its(:stdout) { should match(/^alpine\s.*3.1/) }
 end
 
+describe command('docker images') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^alpine\s.*2.7/) }
+end
+
 # docker_image[vbatts/slackware]
 
 describe command('docker images') do

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -714,3 +714,9 @@ describe command("docker inspect -f '{{ .HostConfig.LogConfig.Config }}' syslogg
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/syslog-tag:container-syslogger/) }
 end
+
+# docker_container[host_override]
+
+describe command("docker ps -af 'name=host_override'") do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -58,6 +58,11 @@ describe command('docker images') do
   its(:stdout) { should match(/^alpine\s.*3.1/) }
 end
 
+describe command('docker images') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^alpine\s.*2.7/) }
+end
+
 # docker_image[vbatts/slackware]
 
 describe command('docker images') do

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -719,3 +719,9 @@ describe command("docker inspect -f '{{ .HostConfig.LogConfig.Config }}' syslogg
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/syslog-tag:container-syslogger/) }
 end
+
+# docker_container[host_override]
+
+describe command("docker ps -af 'name=host_override'") do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -58,6 +58,11 @@ describe command('docker images') do
   its(:stdout) { should match(/^alpine\s.*3.1/) }
 end
 
+describe command('docker images') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/^alpine\s.*2.7/) }
+end
+
 # docker_image[vbatts/slackware]
 
 describe command('docker images') do


### PR DESCRIPTION
-basic support for adding per-resource docker.connection, resolves #322.
-tls is currently not supported, but will be trivial to add support for and i will add when i have extra cycles to burn.