### PR TITLE
Update helpers_service.rb

### DIFF
--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -109,17 +109,21 @@ module DockerHelpers
       [docker_bin, docker_opts].join(' ')
     end
 
-    # loop until docker socker is available
+    # Try to connect to docker socket twenty times
     def docker_wait_ready
       bash 'docker-wait-ready' do
         code <<-EOF
-        while /bin/true; do
+        timeout=0
+        while [ $timeout -lt 20 ];  do
+          ((timeout++))
           #{docker_cmd} ps | head -n 1 | grep ^CONTAINER
           if [ $? -eq 0 ]; then
             break
           fi
           sleep 1
         done
+        [[ $timeout -eq 20 ]] && exit 1
+        exit 0
         EOF
         not_if "#{docker_cmd} ps | head -n 1 | grep ^CONTAINER"
       end


### PR DESCRIPTION
Chef-client shouldn't wait forever for the Docker service to respond. There can be configuration errors, and the execution of chef-client should exit with an error. By adding this timeout we try 20 times to connect to the docker socket, and if it fails to connect, it will exit with 1.