### PR TITLE
removing property_is_set so timeout will be set to our defaults

### DIFF
--- a/libraries/helpers_base.rb
+++ b/libraries/helpers_base.rb
@@ -47,8 +47,8 @@ module DockerHelpers
     def connection
       @connection ||= begin
           opts = {}
-          opts['read_timeout'] = read_timeout if property_is_set?(:read_timeout)
-          opts['write_timeout'] = write_timeout if property_is_set?(:write_timeout)
+          opts['read_timeout'] = read_timeout if read_timeout
+          opts['write_timeout'] = write_timeout if write_timeout
           Docker::Connection.new(host || Docker.url, opts)
         end
     end


### PR DESCRIPTION
https://github.com/chef/chef-rfc/blob/master/rfc054-resource-attribute-improvements.md#property_is_set

the default timeouts are not being set and it is from the property_is_set. described in the rfc above, property_is_set only returns true if the property has a value other than default.

test-kitchen keeps failing on image builds because we specify a timeout of 120 seconds, but it has been failing to set that.