### PR TITLE
LocalJumpError caused by return nil

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,47 +14,97 @@ provisioner:
       container_cmd_timeout: 30
 
 platforms:
-- name: centos-6.5
+- name: centos-6.5-chef-12.4.3
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-centos-6.5
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+
+- name: centos-7.0-chef-12.4.3
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-centos-7.0
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
+
+# *shakes fist at systemd*
+- name: debian-8.1-chef-12.4.3
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-debian-8.1
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1_chef-provisionerless.box
+
+- name: fedora-21-chef-12.4.3
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-fedora-21
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-21_chef-provisionerless.box
+
+- name: ubuntu-12.04-chef-12.4.3
+  run_list:
+    - recipe[apt]
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-ubuntu-12.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+
+- name: ubuntu-14.04-chef-12.4.3
+  run_list:
+    - recipe[apt]
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-ubuntu-14.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+
+- name: ubuntu-15.04-chef-12.4.3
+  run_list:
+    - recipe[apt]
+  driver_config:
+    require_chef_omnibus: 12.4.3
+    box: opscode-ubuntu-15.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-15.04_chef-provisionerless.box
+
+- name: centos-6.5-chef-latest
   driver_config:
     box: opscode-centos-6.5
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
 
-- name: centos-7.0
+- name: centos-7.0-chef-latest
   driver_config:
     box: opscode-centos-7.0
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
 
 # *shakes fist at systemd*
-- name: debian-8.1
+- name: debian-8.1-chef-latest
   driver_config:
     box: opscode-debian-8.1
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1_chef-provisionerless.box
 
-- name: fedora-21
+- name: fedora-21-chef-latest
   driver_config:
     box: opscode-fedora-21
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-21_chef-provisionerless.box
 
-- name: ubuntu-12.04
+- name: ubuntu-12.04-chef-latest
   run_list:
     - recipe[apt]
   driver_config:
     box: opscode-ubuntu-12.04
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
 
-- name: ubuntu-14.04
+- name: ubuntu-14.04-chef-latest
   run_list:
     - recipe[apt]
   driver_config:
     box: opscode-ubuntu-14.04
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
 
-- name: ubuntu-15.04
+- name: ubuntu-15.04-chef-latest
   run_list:
     - recipe[apt]
   driver_config:
     box: opscode-ubuntu-15.04
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-15.04_chef-provisionerless.box
+
 
 suites:
 #
@@ -62,7 +112,8 @@ suites:
 #
 - name: service-socket-execute
   includes: [
-    'ubuntu-15.04'
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -73,7 +124,8 @@ suites:
 
 - name: service-tls-execute
   includes: [
-    'ubuntu-15.04'
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -84,15 +136,24 @@ suites:
 
 - name: service-socket
   includes: [
-    'amazon-2014.09',
-    'fedora-21',
-    'centos-6.5',
-    'centos-7.0',
-    'debian-7.0',
-    'debian-8',
-    'ubuntu-12.04',
-    'ubuntu-14.04',
-    'ubuntu-15.04'
+    'amazon-2014.09-chef-12.4.3',
+    'amazon-2014.09-chef-latest',
+    'fedora-21-chef-12.4.3',
+    'fedora-21-chef-latest',
+    'centos-6.5-chef-12.4.3',
+    'centos-6.5-chef-latest',
+    'centos-7.0-chef-12.4.3',
+    'centos-7.0-chef-latest',
+    'debian-7.0-chef-12.4.3',
+    'debian-7.0-chef-latest',
+    'debian-8-chef-12.4.3',
+    'debian-8-chef-latest',
+    'ubuntu-12.04-chef-12.4.3',
+    'ubuntu-12.04-chef-latest',
+    'ubuntu-14.04-chef-12.4.3',
+    'ubuntu-14.04-chef-latest',
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -102,15 +163,24 @@ suites:
 
 - name: service-tls
   includes: [
-    'amazon-2014.09',
-    'fedora-21',
-    'centos-6.5',
-    'centos-7.0',
-    'debian-7.0',
-    'debian-8',
-    'ubuntu-12.04',
-    'ubuntu-14.04',
-    'ubuntu-15.04',
+    'amazon-2014.09-chef-12.4.3',
+    'amazon-2014.09-chef-latest',
+    'fedora-21-chef-12.4.3',
+    'fedora-21-chef-latest',
+    'centos-6.5-chef-12.4.3',
+    'centos-6.5-chef-latest',
+    'centos-7.0-chef-12.4.3',
+    'centos-7.0-chef-latest',
+    'debian-7.0-chef-12.4.3',
+    'debian-7.0-chef-latest',
+    'debian-8-chef-12.4.3',
+    'debian-8-chef-latest',
+    'ubuntu-12.04-chef-12.4.3',
+    'ubuntu-12.04-chef-latest',
+    'ubuntu-14.04-chef-12.4.3',
+    'ubuntu-14.04-chef-latest',
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -120,11 +190,16 @@ suites:
 
 - name: resources-162
   includes: [
-    'debian-8.1',
-    'centos-7.0',
-    'fedora-21',
-    'ubuntu-14.04',
-    'ubuntu-15.04',
+    'debian-8.1-chef-12.4.3',
+    'debian-8.1-chef-latest',
+    'centos-7.0-chef-12.4.3',
+    'centos-7.0-chef-latest',
+    'fedora-21-chef-12.4.3',
+    'fedora-21-chef-latest',
+    'ubuntu-14.04-chef-12.4.3',
+    'ubuntu-14.04-chef-latest',
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -136,10 +211,14 @@ suites:
 
 - name: resources-171
   includes: [
-    'debian-8.1',
-    'centos-7.0',
-    'fedora-21',
-    'ubuntu-15.04',
+    'debian-8.1-chef-12.4.3',
+    'debian-8.1-chef-latest',
+    'centos-7.0-chef-12.4.3',
+    'centos-7.0-chef-latest',
+    'fedora-21-chef-12.4.3',
+    'fedora-21-chef-latest',
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -152,10 +231,14 @@ suites:
 
 - name: resources-182
   includes: [
-    'debian-8.1',
-    'centos-7.0',
-    'fedora-21',
-    'ubuntu-15.04',
+    'debian-8.1-chef-12.4.3',
+    'debian-8.1-chef-latest',
+    'centos-7.0-chef-12.4.3',
+    'centos-7.0-chef-latest',
+    'fedora-21-chef-12.4.3',
+    'fedora-21-chef-latest',
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -167,7 +250,8 @@ suites:
 
 - name: notifications
   includes: [
-    'ubuntu-15.04'
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:
@@ -177,7 +261,8 @@ suites:
 
 - name: timeout
   includes: [
-    'ubuntu-15.04'
+    'ubuntu-15.04-chef-12.4.3',
+    'ubuntu-15.04-chef-latest'
   ]
   attributes:
     docker:

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -226,8 +226,8 @@ class Chef
       end
 
       action :start do
-        return if state['Restarting']
-        return if state['Running']
+        next if state['Restarting']
+        next if state['Running']
         converge_by "starting #{container_name}" do
           with_retries do
             if detach
@@ -245,7 +245,7 @@ class Chef
       end
 
       action :stop do
-        return unless state['Running']
+        next unless state['Running']
         kill_after_str = " (will kill after #{kill_after}s)" if kill_after != -1
         converge_by "stopping #{container_name}#{kill_after_str}" do
           with_retries { container.stop!('t' => kill_after) }
@@ -253,7 +253,7 @@ class Chef
       end
 
       action :kill do
-        return unless state['Running']
+        next unless state['Running']
         converge_by "killing #{container_name}" do
           with_retries { container.kill(signal: signal) }
         end
@@ -267,19 +267,19 @@ class Chef
       end
 
       action :run_if_missing do
-        return if current_resource
+        next if current_resource
         call_action(:run)
       end
 
       action :pause do
-        return if state['Paused']
+        next if state['Paused']
         converge_by "pausing #{container_name}" do
           with_retries { container.pause }
         end
       end
 
       action :unpause do
-        return if current_resource && !state['Paused']
+        next if current_resource && !state['Paused']
         converge_by "unpausing #{container_name}" do
           with_retries { container.unpause }
         end
@@ -301,7 +301,7 @@ class Chef
       end
 
       action :delete do
-        return unless current_resource
+        next unless current_resource
         call_action(:unpause)
         call_action(:stop)
         converge_by "deleting #{container_name}" do

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -42,12 +42,12 @@ class Chef
       end
 
       action :build_if_missing do
-        return if Docker::Image.exist?(image_identifier, {}, connection)
+        next if Docker::Image.exist?(image_identifier, {}, connection)
         action_build
       end
 
       action :import do
-        return if Docker::Image.exist?(image_identifier, {}, connection)
+        next if Docker::Image.exist?(image_identifier, {}, connection)
         converge_by "Import image #{image_identifier}" do
           import_image
         end
@@ -60,7 +60,7 @@ class Chef
       end
 
       action :pull_if_missing do
-        return if Docker::Image.exist?(image_identifier, {}, connection)
+        next if Docker::Image.exist?(image_identifier, {}, connection)
         action_pull
       end
 
@@ -71,7 +71,7 @@ class Chef
       end
 
       action :remove do
-        return unless Docker::Image.exist?(image_identifier, {}, connection)
+        next unless Docker::Image.exist?(image_identifier, {}, connection)
         converge_by "Remove image #{image_identifier}" do
           remove_image
         end

--- a/libraries/docker_tag.rb
+++ b/libraries/docker_tag.rb
@@ -13,7 +13,7 @@ class Chef
       #########
 
       action :tag do
-        return if Docker::Image.exist?("#{to_repo}:#{to_tag}")
+        next if Docker::Image.exist?("#{to_repo}:#{to_tag}")
         begin
           converge_by "update #{target_repo}:#{target_tag} to #{to_repo}:#{to_tag}" do
             i = Docker::Image.get("#{target_repo}:#{target_tag}")


### PR DESCRIPTION
added chef-client 12.4.3 and latest to kitchen for the time being. this was an issue present only in 12.4.3 and not in 12.5.1 because of compat_resource. we should test against both versions for a bit.

resolves #500 and #501