### PR TITLE
changing container resource to default action :run

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,8 +939,9 @@ Most `docker_container` properties are the `snake_case` version of the
   Volume containers.
 - `:start` - Starts the container. Useful for containers that run
   jobs.. command that exit.
-- `:run` - Both `:create` and `:start` the container in one action.
-- `:run_if_missing` - The default action. Runs a container only once.
+- `:run` - The default action. Both `:create` and `:start` the container in one action.
+  Redeploys the container on resource change.
+- `:run_if_missing` - Runs a container only once.
 - `:stop` - Stops the container.
 - `:restart` - Stops the starts the container.
 - `:kill` - Send a signal to the container process. Defaults to `SIGKILL`.

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -146,7 +146,7 @@ class Chef
       # Super handy visual reference!
       # http://gliderlabs.com/images/docker_events.png
 
-      default_action :run_if_missing
+      default_action :run
 
       declare_action_class.class_eval do
         def call_action(action)

--- a/test/cookbooks/docker_test/recipes/container.rb
+++ b/test/cookbooks/docker_test/recipes/container.rb
@@ -303,6 +303,7 @@ docker_container 'ohai_debian' do
   command '/opt/chef/embedded/bin/ohai platform'
   repo 'debian'
   volumes_from 'chef_container'
+  action :run_if_missing
 end
 
 #####
@@ -738,6 +739,7 @@ docker_container 'api_timeouts' do
   tag '3.1'
   read_timeout 60
   write_timeout 60
+  action :run_if_missing
 end
 
 ##############
@@ -858,4 +860,5 @@ docker_container 'syslogger' do
   tag '3.1'
   log_driver 'syslog'
   log_opts 'syslog-tag=container-syslogger'
+  action :run_if_missing
 end


### PR DESCRIPTION
action run has become very stable since we switched to using the new custom resource. i think run should become the new default so containers will be redeployed on resource changes.