### PR TITLE
daemon can accept multiple labels. updating README. string is valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ the options found in the
 - `iptables` - Enable addition of iptables rules
 - `ipv6` - Enable IPv6 networking
 - `log_level` - Set the logging level
-- `label` - Set key=value labels to the daemon
+- `labels` A string or array to set metadata on the daemon in the form
+  ['foo:bar', 'hello:world']`
 - `log_driver` - Container's logging driver (json-file/syslog/journald/gelf/fluentd/none)
 - `log_opts` - Container's logging driver options (driver-specific)
 - `mtu` - Set the containers network MTU
@@ -887,8 +888,8 @@ Most `docker_container` properties are the `snake_case` version of the
 - `host` - A string containing the host the API should communicate with.
   Defaults to local `docker_service`.
 - `host_name` - The hostname for the container.
-- `labels` A hash or array to set metadata on the container in the form
-  ['foo=bar', 'hello=world']`
+- `labels` A string, array, or hash to set metadata on the container in the form
+  ['foo:bar', 'hello:world']`
 - `links` - An array of source container/alias pairs to link the
   container to in the form `[container_a:www', container_b:db']`
 - `log_driver` - Sets a custom logging driver for the container

--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -55,7 +55,7 @@ class Chef
       property :force, Boolean
       property :host, [String, nil], desired_state: false
       property :hostname, [String, nil]
-      property :labels, [Hash, nil], coerce: proc { |v| coerce_labels(v) }
+      property :labels, [String, Array, Hash], coerce: proc { |v| coerce_labels(v) }
       property :links, [Array, nil], coerce: proc { |v| coerce_links(v) }
       property :log_driver, %w( json-file syslog journald gelf fluentd none ), default: 'json-file'
       property :log_opts, [Hash, nil], coerce: proc { |v| coerce_log_opts(v) }

--- a/libraries/docker_service.rb
+++ b/libraries/docker_service.rb
@@ -39,7 +39,7 @@ class Chef
       property :iptables, [Boolean, nil]
       property :ipv6, [Boolean, nil]
       property :log_level, [:debug, :info, :warn, :error, :fatal, nil]
-      property :label, [String, nil]
+      property :labels, [String, Array], coerce: proc { |v| coerce_daemon_labels(v) }
       property :log_driver, ['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'none', nil]
       property :log_opts, ArrayType
       property :mtu, [String, nil]
@@ -67,6 +67,7 @@ class Chef
       # logging
       property :logfile, String, default: '/var/log/docker.log'
 
+      alias_method :label, :labels
       alias_method :tlscacert, :tls_ca_cert
       alias_method :tlscert, :tls_server_cert
       alias_method :tlskey, :tls_server_key

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -60,15 +60,20 @@ module DockerHelpers
 
     def coerce_host(v)
       v = v.split if v.is_a?(String)
-      r = []
-      Array(v).each do |s|
+      Array(v).each_with_object([]) do |s, r|
         if s.match(/^unix:/) || s.match(/^tcp:/) || s.match(/^fd:/)
           r << s
         else
           Chef::Log.info("WARNING: docker_service host property #{s} not valid")
         end
       end
-      r
+    end
+
+    def coerce_daemon_labels(v)
+      Array(v).each_with_object([]) do |label, a|
+        parts = label.split(':')
+        a << "#{parts[0]}=\"#{parts[1]}\""
+      end
     end
 
     def default_checksum
@@ -171,7 +176,7 @@ module DockerHelpers
       opts << "--iptables=#{iptables}" unless iptables.nil?
       opts << "--ipv6=#{ipv6}" unless ipv6.nil?
       opts << "--log-level=#{log_level}" if log_level
-      opts << "--label=#{label}" if label
+      labels.each { |l| opts << "--label=#{l}" } if labels
       opts << "--log-driver=#{log_driver}" if log_driver
       log_opts.each { |log_opt| opts << "--log-opt=#{log_opt}" } if log_opts
       opts << "--mtu=#{mtu}" if mtu

--- a/test/cookbooks/docker_test/recipes/default.rb
+++ b/test/cookbooks/docker_test/recipes/default.rb
@@ -1,6 +1,7 @@
 docker_service 'default' do
   host ['unix:///var/run/docker.sock', 'tcp://127.0.0.1:2376']
   version node['docker']['version']
+  labels ['environment:test', 'foo:bar']
   # storage_driver 'overlay'
   action [:create, :start]
 end

--- a/test/integration/resources-162/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-162/serverspec/assert_functioning_spec.rb
@@ -28,6 +28,18 @@ nil_string = '<no value>' if docker_version =~ /1.6/
 nil_string = '<nil>' if docker_version =~ /1.7/
 nil_string = '<nil>' if docker_version =~ /1.8/
 
+##################################################
+#  test/cookbooks/docker_test/recipes/default.rb
+##################################################
+
+# docker_service[default]
+
+describe command('docker info') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/environment="test"/) }
+  its(:stdout) { should match(/foo="bar"/) }
+end
+
 ##############################################
 #  test/cookbooks/docker_test/recipes/image.rb
 ##############################################

--- a/test/integration/resources-171/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-171/serverspec/assert_functioning_spec.rb
@@ -28,6 +28,18 @@ nil_string = '<no value>' if docker_version =~ /1.6/
 nil_string = '<nil>' if docker_version =~ /1.7/
 nil_string = '<nil>' if docker_version =~ /1.8/
 
+##################################################
+#  test/cookbooks/docker_test/recipes/default.rb
+##################################################
+
+# docker_service[default]
+
+describe command('docker info') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/environment="test"/) }
+  its(:stdout) { should match(/foo="bar"/) }
+end
+
 ##############################################
 #  test/cookbooks/docker_test/recipes/image.rb
 ##############################################

--- a/test/integration/resources-182/serverspec/assert_functioning_spec.rb
+++ b/test/integration/resources-182/serverspec/assert_functioning_spec.rb
@@ -28,6 +28,18 @@ nil_string = '<no value>' if docker_version =~ /1.6/
 nil_string = '<nil>' if docker_version =~ /1.7/
 nil_string = '<nil>' if docker_version =~ /1.8/
 
+##################################################
+#  test/cookbooks/docker_test/recipes/default.rb
+##################################################
+
+# docker_service[default]
+
+describe command('docker info') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/environment="test"/) }
+  its(:stdout) { should match(/foo="bar"/) }
+end
+
 ##############################################
 #  test/cookbooks/docker_test/recipes/image.rb
 ##############################################
@@ -637,9 +649,11 @@ if docker_version.to_f > 1.6
     its(:stdout) { should match(/#{uber_options_network_mode}/) }
   end
 
+  # docker inspect returns the labels unsorted
   describe command("docker inspect -f '{{ .Config.Labels }}' uber_options") do
     its(:exit_status) { should eq 0 }
-    its(:stdout) { should match(/foo:bar hello:world/) }
+    its(:stdout) { should match(/foo:bar/) }
+    its(:stdout) { should match(/hello:world/) }
   end
 end
 


### PR DESCRIPTION
adding label support to the daemon. also, occasionally docker inspect returns container labels unsorted and causes rspec to fail; implemented fix for this.  