### PR TITLE
adding why_run support

### DIFF
--- a/libraries/docker_container.rb
+++ b/libraries/docker_container.rb
@@ -148,6 +148,10 @@ class Chef
       default_action :run
 
       declare_action_class.class_eval do
+        def whyrun_supported?
+          true
+        end
+
         def call_action(action)
           send("action_#{action}")
           load_current_resource

--- a/libraries/docker_image.rb
+++ b/libraries/docker_image.rb
@@ -33,6 +33,9 @@ class Chef
 
       declare_action_class.class_eval do
         include DockerHelpers::Image
+        def whyrun_supported?
+          true
+        end
       end
 
       action :build do


### PR DESCRIPTION
the only small issue with this, which isnt really harmful, is action :pull will actually pull the latest image even with whyrun because the comparison happens after we create a new image and compare old id with new id. still researching on how to compare local and repo image without performing an Image.create.

resolves #522